### PR TITLE
Added License and copyright to needed files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,17 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 machine:
   environment:
     PATH: $PATH:node_modules/.bin

--- a/config/example-config.yml
+++ b/config/example-config.yml
@@ -1,3 +1,17 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 aws-access-key: PPP
 aws-secret-key: QQQ
 aws-default-region: us-east-1

--- a/deploy/pentagon-production.configmap.yml
+++ b/deploy/pentagon-production.configmap.yml
@@ -1,3 +1,17 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/pentagon.deployment.yml
+++ b/deploy/pentagon.deployment.yml
@@ -1,3 +1,16 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deploy/pentagon.service.yml
+++ b/deploy/pentagon.service.yml
@@ -1,3 +1,16 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 ---
 apiVersion: v1
 kind: Service

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,17 @@
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
 site_name: Pentagon
 theme: readthedocs
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+#Copyright 2017 Reactive Ops Inc.
+#
+#Licensed under the Apache License, Version 2.0 (the “License”);
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an “AS IS” BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 
 import os
 import sys


### PR DESCRIPTION
Intentionally left off anything in /lib because those are templates
that will be copied elsewhere.

```
Copyright 2017 Reactive Ops Inc.

Licensed under the Apache License, Version 2.0 (the “License”);
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an “AS IS” BASIS,

WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
implied.
See the License for the specific language governing permissions and
limitations under the License.
```