### PR TITLE
WIP: End-user Kubernetes docs, runbooks and templates

### DIFF
--- a/lib/pentagon/docs/application-lifecycle.md
+++ b/lib/pentagon/docs/application-lifecycle.md
@@ -1,0 +1,152 @@
+# Application Lifecycle
+
+[Onboard an application](#onboard-an-application)
+
+[Deploy an application build](#deploy-an-application-build)
+
+[Release an application](#release-an-application)
+
+[Rollback an application](#rollback-an-application)
+
+[End-of-life an application](#end-of-life-an-application)
+
+## Onboard an application
+
+1) identify context (cluster + namespace) you would like to target [[see docs](setting-context.md)]
+
+`$ kubectl config use-context staging`
+
+2) define `Secrets` that application will need injected at runtime [[see docs](http://kubernetes.io/docs/user-guide/secrets/#creating-your-own-secrets)]
+
+`$ kubectl apply -f secret.yaml`
+
+3) define `ConfigMap` for non-sensitive environmental variables to inject at runtime [[app configmap template](../kubernetes-templates/example-app-staging.configmap.yml)][[see docs](http://kubernetes.io/docs/user-guide/configmap/)]
+
+`$ kubectl apply -f configmap.yaml --record`
+
+4) write `Service` (if static address/public presence is necessary) based on provided templates. If not behind `cluster-proxy` uncomment ELB configuration line. [[app service template](../kubernetes-templates/example-app.service.yml)] [[docs](http://kubernetes.io/docs/user-guide/services/)]
+
+`$ kubectl create -f service.yaml --record`
+
+5) write `Deployment` based on provided templates. modify at least `name`, `labels`, `image` and `env` vars. see documentation about leveraging Secrets and ConfigMaps in your deployment.
+[[app deployment template](../kubernetes-templates/example-app/deployment.yml)] [[worker deployment template](../kubernetes-templates/example-worker/deployment.yml)] [[docs](http://kubernetes.io/docs/user-guide/deployments/)]
+
+`$ kubectl create -f deployment.yaml --record`
+
+
+## Deploy an application build
+
+1) identify context (cluster + namespace) you would like to target [[see docs](setting-context.md)]
+
+`$ kubectl config use-context staging-secure`
+
+2) update `Secrets`
+
+`$ kubectl apply -f secret.yaml`
+
+3) update `ConfigMaps`
+
+`$ kubectl apply -f configmap.yaml --record`
+
+4) update `Service`
+
+(if exists already and is changing)
+```
+$ kubectl get service <service-name>
+$ kubectl apply -f service.yaml --record
+```
+
+or
+
+(if doesn't exist)
+
+`$ kubectl create -f service.yaml --record`
+
+5) update `Deployment`
+
+(if exists already and is changing)
+
+```
+$ kubectl get deployment <deployment-name>
+$ sed 's/:latest/':${CI_SHA1}'/g;' deployment.yaml > deployment.yaml-${CI_SHA1}
+$ kubectl apply -f deployment.yaml-${CI_SHA1}
+```
+
+**Note**: `CI_SHA1` here is the build SHA you are deploying. Being explicit about SHA to deploy is best practice (instead of using latest).
+
+(if doesn't exist)
+
+`$ kubectl create -f deployment.yaml`
+
+6) wait for `Deployment` to finish successfully. watch for `updatedReplicas` and `availableReplicas`
+
+`$ kubectl get deployment <deployment-name> -o yaml`
+
+
+## Release an application
+
+The patterns currently used with Kubernetes make no distinction between a deployment to `production` or `secure-production` and a "release."  
+
+`Deployments` are not currently immutable in the sense that there is not a new, unique `Deployment` resource with a unique identifier created for each deploy.  
+
+Rather, the `Deployment` resource for a particular application/service is updated with a new `image` (identified by SHA) and applied in-place.  Using this method, Kubernetes detects the change in `Deployment` and spawns a new `Replica Set` which spawns the new `Pods`.  
+
+The `Service` resource, which provides the static IP/ELB interface for the new `Pods`, selects its backend resources by `selector`.  This `selector` field defines a label used to identify the correct backing application `Pods`. These labels to not change between deployment and so the label selector is also static.  
+
+All of this adds up to the fact that there is no real "release" point where a `Service` is cut-over or swapped over to a full set of new `Pods`.  Rather, a `RollingUpdate` is used where the new Pods coming online are added to the Service as older Pods are removed.
+
+### tl;dr
+
+A **release** essentially happens, when `kubectl apply -f deployment.yaml-${CI_SHA}` is run in one of the production contexts
+
+If a different solution is needed, it may be useful to look in to deploying with a certain label that is attached to a private `Service` and then modifying labels when the release happens. If the modified label is attached to a public `Service`, this may be sufficient, though a method to roll-off older `Pods` would also be needed`.
+
+## Rollback an application
+
+1) identify context (cluster + namespace) you would like to target [[see docs](setting-context.md)]
+
+`$ kubectl config use-context staging-secure`
+
+2) check the change history (deployment revisions)
+
+`$ kubectl rollout history deployment/example-app`
+
+`$ kubectl rollout history deployment/example-app --revision=_N_`
+
+3) rollback to a previous revision
+
+`$ kubectl rollout undo deployment/example-app`
+
+`$ kubectl rollout undo deployment/example-app --to-revision=_N_`
+
+4) wait for undo to finish successfully. watch for `updatedReplicas` and `availableReplicas`
+
+`$ kubectl get deployment <deployment-name> -o yaml`
+
+## End-of-life an application
+
+1) identify context (cluster + namespace) you would like to target [[see docs](setting-context.md)]
+
+`$ kubectl config use-context staging-secure`
+
+2) remove `Secrets`
+
+`$ kubectl delete -f secret.yaml`
+
+3) remove `ConfigMaps`
+
+`$ kubectl delete -f configmap.yaml --record`
+
+4) remove `Services`
+
+`$ kubectl delete -f service.yaml --record`
+
+5) remove `Deployments`
+
+`$ kubectl delete -f deployment.yaml --record`
+
+6) clean up old `ReplicaSets`
+
+```
+$ for r in `kubectl get rs | grep <deployment-name> | awk '{print $1}'` ; do kubectl delete replicaset/$r; done
+```

--- a/lib/pentagon/docs/autoscaling.md
+++ b/lib/pentagon/docs/autoscaling.md
@@ -1,0 +1,52 @@
+# Autoscaling
+
+Autoscaling for Kubernetes can be broken into 2 groups, cluster autoscaling and pod autoscaling.
+**With both mechanisms it is required that you use** [**resource requests**](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) **for all* pods**.
+
+*Not really ALL. Daemonsets could be a good reason not to include requests, there may be others. If you don’t have a great reason to omit resource requests, INCLUDE THEM.
+****
+## Cluster Autoscaling
+
+The Kubernetes cluster is scaled using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). There is [an alternative](https://github.com/hjacobs/kube-aws-autoscaler) we may try eventually.
+
+The Autoscaler (or similar mechanism) is needed as **standard ASG scaling metrics will not work well with Kubernetes**. The use of requests/limits (critical to good operation of the Kubernetes scheduler) means that the actual CPU/memory usage of an instance it not a good indicator of when to scale the cluster. It is possible that the Kubernetes scheduler believes all resources are allocated (and needs more) but the actual CPU usage is very low.
+
+Example:
+
+
+- Cluster has 3000m CPU available.
+- 5 pods are deployed each with 500m CPU requested (2500m in use). 
+- These apps aren’t use, and are actually mostly idle. The EC2 instance average cpu usage is 10%. 
+- Attempting to deploy a single pod of 1000m would be 3500m/3000.
+- Kubernetes needs to scale, but using EC2 CPU usage wouldn’t tell us that. 
+
+The Cluster Autoscaler uses a control-loop to query for pods that cannot be scheduled. If there are pods that cannot be scheduled the Autoscaler attempts to scale the cluster.  This uses a simplified scheduling algorithm and can be tuned for varied behavior when scaling. 
+
+**The Autoscaler will not scale if there was a recent scaling event**. This leads to the need to tune how much to scale depending on cluster size as the delay between scaling events can mean the cluster is not scaling quickly enough. 
+
+The Cluster Autoscaler configuration needs match the same number of nodes as the actual ASG. Otherwise the Autoscaler may fail to manipulate the ASG.
+
+**Scaling down**
+We've seen cases where some nodes are not removed due to kube-system resources being deployed there. This doesn't break anything by not being able to scale down those nodes, just may cost more in smaller clusters where other nodes won’t be removed.
+
+**Changing ASG Sizes**
+There are a couple of steps involved with changing the autoscaling size of the cluster
+
+- Edit the instance group `kops edit instancegroup nodes` changing `spec.minSize` and `spec.maxSize` as appropriate.
+- Update the `cluster-autoscaler.yml` file in `$CLIENT-infrastructure/default/clusters/$CLUSTER/kubernetes/` for the new ASG size. This should be in the `spec.template.spec.containers[].command` updating the `--nodes` numbers. Apply the file with `kubectl apply -f $FILE`.
+- Update the weave connection limit in the `weave.yml` file in `$CLIENT-infrastructure/default/clusters/$CLUSTER/kubernetes/`. This should be larger than the max number of nodes (try 2x the max).  Apply the file with `kubectl apply -f $FILE`.
+- Update the cluster `kops update cluster` to review the changes then `kops update cluster --yes` to apply them. 
+## Horizontal Pod Autoscaling
+
+With requests/limits in place per-pod there is a need to deploy more (or fewer) pods depending on the current workload. The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) handles setting the number of replicas of a pod. This can use CPU or memory, or a custom metric (although changes depending on Kube version). 
+
+CPU usage is generally a good metric to use.  Resource requests for the pod will need to be high enough to account for the application startup which in smaller scales may dominate the resource usage.  500m is a reasonable minimum to use. 
+
+With HPA you may be able to maintain a single deployment file. In many cases the `replicas` number may be all that changes. If that is the case you can use HPA to set the number (even if it’s static) and maintain only 1 deployment file.
+
+
+## HPA, Cluster Autoscalers, Deployments, AND YOU!
+
+The HPA and Cluster Autoscaler combine to attempt to properly scale a Kubernetes cluster and the deployed applications. This means that when deploying new code to Kubernetes there may not be enough room for even 1 more pod. Eventually this leads to a scaling event for the ASG but a delay in the deployment. Consequently this is one of the reasons another autoscaler may be more useful, allowing over-provisioning to work around this.
+
+We do not yet have guidelines on how shorten this delay.  There are multiple parameters that can be changed on deployments to alter how many pods are changing at one time that may be able to solve this. 

--- a/lib/pentagon/docs/configmaps.md
+++ b/lib/pentagon/docs/configmaps.md
@@ -1,0 +1,242 @@
+# ConfigMaps
+
+> **Do not forget to set your Kubernetes context _first_ by following the [setting-context](setting-context.md) documentation**
+
+## tl;dr
+
+
+**Create a ConfigMap from a ConfigMap document**
+
+> `$ kubectl apply -f example-app-staging.configmap.yml --record`
+
+**Create a ConfigMap from a file of key-value pairs**
+
+
+> `$ kubectl create configmap example-app --from-file=example-app-staging.configmap.yml --record`
+
+**Create a ConfigMap from literal values**
+
+> `$ kubectl create configmap example-app --from-literal=rails_env=staging --from-literal=rack_env=staging --record`
+
+**Consume ConfigMap values in a pod**
+
+```      
+	env:
+        - name: RAILS_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: example-app
+              key: rails_env
+        - name: RACK_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: example-app
+              key: rack_env
+
+```
+
+**Update a ConfigMap and restart Pod to pick up changes**
+
+> `$ kubectl apply -f example-app-staging.configmap.yml`
+>
+> `$kubectl patch deployment example-app -p '{"spec":{"template":{"spec":{"containers":[{"name":"example-app","env":[{"name":"RESTART_","value":"'$(date +%s)'"}]}]}}}}'`
+
+
+## Writing a ConfigMap
+
+Many applications require configuration via some combination of config files, command line arguments, and environment variables. These configuration artifacts should be decoupled from image content in order to keep containerized applications portable. 
+
+The ConfigMap API resource provides mechanisms to inject containers with configuration data while keeping containers agnostic of Kubernetes. ConfigMap can be used to store fine-grained information like individual properties or coarse-grained information like entire config files or JSON blobs.
+
+The ConfigMap API resource holds key-value pairs of configuration data that can be consumed in pods or used to store configuration data for system components such as controllers. ConfigMap is similar to Secret, but designed to more conveniently support working with strings that do not contain sensitive information.
+
+Example:
+
+`example-app-staging.configmap.yml`
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-app
+data:
+  db-host:                     'example-db.example.com'
+  db-username:                 'example-db-user'
+  db-database-name:            'example-app'
+  rack-env:                    'staging'
+  rails-env:                   'staging'
+```
+
+## Creating a ConfigMap from a file
+
+When creating a ConfigMap from an existing file, we can use one of two formats
+1. a well formed, complete Kubernetes ConfigMap document
+2. a plain text file of key-value pairs
+
+### From a well formed, complete ConfigMap document
+
+A ConfigMap document is written in YAML, as with other Kubernetes resources, and provides both the data and metadata for the ConfigMap object being created. By writing your own ConfigMap document, you have the power to format the data structure however you need it to be nested, formated, etc. You can also be explicit about the metadata, labels, etc attributed to it.
+
+Example:
+
+`example-app-staging.configmap.yml`
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-app
+data:
+  db-host:                     'example-db.example.com'
+  db-username:                 'example-db-user'
+  db-database-name:            'example-app'
+  rack-env:                    'staging'
+  rails-env:                   'staging'
+```
+
+Since the ConfigMap document is essentially already created, we use the `kubectl apply` command rather than create.
+
+`$kubectl apply -f example-app-staging.configmap.yml --record`
+
+```
+$ kubectl get configmaps example-app -o yaml
+apiVersion: v1
+data:
+  db-host='example-db.example.com'
+  db-username='example-db-user'
+  db-database-name='example-app'
+  rack-env='staging'
+  rails-env='staging'
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-11-23T21:57:56Z
+  name: example-app
+...
+```
+
+### From a file of key-value pairs
+
+A plain-text file with key-value pairs can provide the necessary information to populate a ConfigMap. Ensure that there is one key-value pair per line, and quote values properly.
+
+```
+$ cat example-app.properties
+db-host='example-db.example.com'
+db-username='example-db-user'
+db-database-name='example-app'
+rack-env='staging'
+rails-env='staging'
+```
+
+Now, run `kubectl create configmap` with a desired name for the ConfigMap and the source file we created above.
+
+`$ kubectl create configmap example-app --from-file=example-app.properties`
+
+```
+$ kubectl get configmaps example-app -o yaml
+apiVersion: v1
+data:
+  example-app.properties: |-
+    db-host='example-db.example.com'
+    db-username='example-db-user'
+    db-database-name='example-app'
+    rack-env='staging'
+    rails-env='staging'
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-11-23T11:32:22Z
+  name: example-app
+  namespace: secure-staging
+...
+```
+
+ConfigMaps created in such a manner will prefix all the values with the name of the file you've used to seed it. (e.g. `example-app.properties.db-host`) Keep this in mind when consuming ConfigMap values in other resources.
+
+## Create a ConfigMap from literal values
+
+It is also possible to supply literal values for ConfigMaps using kubectl create configmap. The `--from-literal` option takes a key=value syntax that allows literal values to be supplied directly on the command line
+
+`$ kubectl create configmap example --from-literal=db-host=example-db.example.com --from-literal=db-username=example-db-user`
+
+```
+$ kubectl get configmaps example-app -o yaml
+apiVersion: v1
+data:
+  db-host='example-db.example.com'
+  db-username='example-db-user'
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-11-23T11:32:22Z
+  name: example-app
+  namespace: secure-staging
+...
+```
+
+As using this method provides little configuration management and auditing options, since no record of the literals used are kept outside of Kubernetes, it is not always the best option.  It may, however, come in handy if scripted to accept values programmatically from other sources.
+
+## Consuming ConfigMap as environment variables
+
+Many programs read their configuration from environment variables. ConfigMap should be possible to consume in environment variables. The rough series of events for consuming ConfigMap this way is:
+
+- A ConfigMap object is created
+- A pod that consumes the configuration data via environment variables is created
+- The pod is scheduled onto a node
+- The kubelet retrieves the ConfigMap resource(s) referenced by the pod and starts the container processes with the appropriate data in environment variables
+
+
+## Update a ConfigMap and consume new values
+
+
+### From a well formed, complete ConfigMap document
+
+If you have a complete ConfigMap document that lives under configuration management, it is quite easy to update ConfigMap values.  First, edit the document you wish to change and save it.  In the following example we will modify the `db-host` and `db-username`:
+
+`example-app-staging.configmap.yml`
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-app
+data:
+  db-host:                     'db.example.com'
+  db-username:                 'db-user'
+  db-database-name:            'example-app'
+  rack-env:                    'staging'
+  rails-env:                   'staging'
+```
+
+Now, we need to apply the changes, this involves using the `kubectl apply` command and specifying the newly saved file, to apply changes.
+
+`$ kubectl apply -f example-app-staging.configmap.yml`
+
+If we take a look at our modified configmap using `kubectl get configmaps` we can see that the values have been updated properly. Furthermore, annotations will have been added to the metadata showing what changes have been made and by what method.  
+
+```
+$ kubectl get configmaps example-app -o yaml
+apiVersion: v1
+data:
+  db-host='db.example.com'
+  db-username='db-user'
+  db-database-name='example-app'
+  rack-env='staging'
+  rails-env='staging'
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2016-11-23T11:32:22Z
+  name: example-app
+  namespace: secure-staging
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '...'
+    kubernetes.io/change-cause: kubectl apply -f example-app-staging.configmap.yml
+...
+```
+
+Finally, we'll need to ensure that `Pods` and containers that have already been deployed are updated with the new values in the updated ConfigMap.  Since containers must be recreated to pick up new ENV vars, we must destroy those currently running and create new ones.  This can be done in several dirty ways, and Kubernetes does not currently (as of v1.4) have a good way to do a rolling update with `Deployments`.  
+
+Therefore we choose to use a workaround which does and in-place update of the existing deployment and causes a new `ReplicaSet` to be spawned and thus new `Pods` with the new config values.
+
+Using the `kubectl patch deployment` command, we take the dummy ENV variable `RESTART_` which should exist in the `Deployment` (those created from the latest [template](../kubernetes-templates/example-app.deployment.yml) should already include this variable), and we set its value to the current `date`. The command looks something like the following:
+
+```
+$kubectl patch deployment example-app -p '{"spec":{"template":{"spec":{"containers":[{"name":"example-app","env":[{"name":"RESTART_","value":"'$(date +%s)'"}]}]}}}}'
+```

--- a/lib/pentagon/docs/deployments.md
+++ b/lib/pentagon/docs/deployments.md
@@ -1,5 +1,11 @@
 # Deployments
 
+Deployments manage Replica Sets of pods. Deleting a Deployment will not remove the Replica Set. 
+
+For Pentagon users we suggest following [`rok8s-scripts`](https://github.com/reactiveops/rok8s-scripts) for deployments  [examples here](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/production-ready/deploy). Be sure to set `revisionHistoryLimit` at minimum to prevent old Replica Sets from accumulating in Kubernetes.
+
+For more generic documentation on deployments see below.
+
 > **Do not forget to set your Kubernetes context _first_ by following the [setting-context](setting-context.md) documentation**
 
 ## tl;dr

--- a/lib/pentagon/docs/deployments.md
+++ b/lib/pentagon/docs/deployments.md
@@ -1,0 +1,265 @@
+# Deployments
+
+> **Do not forget to set your Kubernetes context _first_ by following the [setting-context](setting-context.md) documentation**
+
+## tl;dr
+
+**Create a Deployment**
+
+> $ kubectl run example-app --image=quay.io/reactiveops/example-app --replicas=3 --generator=deployment/v1beta1
+
+**Watch the Deployment status**
+
+> $ kubectl rollout status deployment/example-app 
+
+**Update the Deployment**
+
+> $ kubectl set image deployment/example-app --container=example-app --image=quay.io/reactiveops/example-app:_some-version_
+
+**Pause the Deployment**
+
+> $ kubectl rollout pause deployment/example-app
+
+**Resume the Deployment**
+
+> $ kubectl rollout resume deployment/example-app
+
+**Check the change history (deployment revisions)**
+
+> $ kubectl rollout history deployment/example-app
+>
+> $ kubectl rollout history deployment/example-app --revision=_N_
+
+**Rollback to a previous version**
+
+> $ kubectl rollout undo deployment/example-app
+> 
+> $ kubectl rollout undo deployment/example-app --to-revision=_N_
+
+## Writing a Deployment File
+
+Templated `Deployment` files have been created to give a good starting point.
+
+Example application `Deployment`:
+
+[example-app.deployment.yml](kubernetes-templates/example-app.deployment.yml)
+
+Example worker `Deployment`:
+
+[example-worker.deployment.yml](kubernetes-templates/example-worker.deployment.yml)
+
+Lots of customization can be done based on the specifics of the application or worker in question.
+
+Of note:
+
+- `replicas`: number of copies of the defined Pod you would like to maintain
+- `template`: template of the Pod you would like to create for this Deployment
+  - `imagePullSecrets`: name of the Kubernetes Secret used to connect to the private Docker registry (in this case quay.io) to allow Kubernetes to pull the image
+  - `image`: quay.io url of Docker image for your application
+  - `containerPort`: port of the application running in your container 
+  - `livenessProbe` and `readinessProbe`: define healthchecks for your container
+  - `env`: environmental variables with which to start the Pod
+	  - notice that most env vars are injected via a `configMapKeyRef` or `secretKeyRef` which belong to corresponding Kubernetes `ConfigMap` and `Secret` resources
+	  - defining variables in a Kubernetes `ConfigMap` or `Secret` will allow you to reuse this information across Deployments
+
+For more options available for use in Deployments, see > [http://kubernetes.io/docs/user-guide/deployments/#writing-a-deployment-spec](http://kubernetes.io/docs/user-guide/deployments/#writing-a-deployment-spec)
+
+## Create a Deployment
+
+The following command will take the `Deployment` configuration you've written from the file you specify and create a `Deployment` resource within the namespace you specify. 
+
+```
+$kubectl create -f example-app.deployment.yaml --record
+deployment "example-app" created
+```
+
+## Watch the Deployment Status
+
+After creating or updating a `Deployment`, you would want to confirm whether it succeeded or not. The simplest way to do this is through `kubectl rollout status`.
+
+```
+$kubectl rollout status deployment/example-app
+deployment example-app successfully rolled out
+```
+
+This verifies the `Deployment`’s .status.observedGeneration >= .metadata.generation, and its up-to-date replicas (.status.updatedReplicas) matches the desired replicas (.spec.replicas) to determine if the rollout succeeded. 
+
+If the rollout is still in progress, it watches for `Deployment` status changes and prints related messages.
+
+```
+$kubectl rollout status deployment/example-app
+Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
+deployment example-app successfully rolled out
+```
+
+If the above command doesn’t return success, you’ll need to timeout and give up at some point.
+
+```
+$kubectl get deployments
+NAME               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+example-app   3         3         3            3           20s
+```
+
+## Update the Deployment
+
+A `Deployment`’s rollout is triggered if and only if the `Deployment`’s pod template (i.e. .spec.template) is changed, e.g. updating labels or container images of the template. **Other updates, such as scaling the `Deployment`, will not trigger a rollout.**
+
+Suppose that we now want to update the example-app Pods to start using the example-app:1.0.0 image instead of the example-app:1.0.1 image.
+
+```
+$kubectl set image deployment/example-app --container=example-app --image=quay.io/reactiveops/example-app:1.0.1 
+deployment "example-app" image updated
+```
+
+Alternatively, we can edit the `Deployment` and change .spec.template.spec.containers[0].image from example-app:1.0.0 to example-app:1.0.1:
+
+```
+$kubectl edit deployment/example-app
+deployment "example-app" edited
+```
+
+We can run `kubectl get rs` to see that the `Deployment` updated the `Pods` by creating a new `Replica Set` and scaling it up to 3 replicas, as well as scaling down the old Replica Set to 0 replicas.
+
+```
+$kubectl get rs
+NAME                          DESIRED   CURRENT   AGE
+example-app-1564180365   3         3         6s
+example-app-2035384211   0         0         36s
+```
+
+Running get pods should now show only the updated `Pods`
+
+```
+$kubectl get pods
+NAME                                READY     STATUS    RESTARTS   AGE
+example-app-1564180365-khku8   1/1       Running   0          14s
+example-app-1564180365-nacti   1/1       Running   0          14s
+example-app-1564180365-z9gth   1/1       Running   0          14s
+```
+
+## Pausing and Resuming the Deployment
+
+You can also pause a `Deployment` mid-way and then resume it. A use case is to support canary deployment.
+
+```
+$kubectl set image deployment/example-app --container=example-app --image=quay.io/reactiveops/example-app:1.0.1; kubectl rollout pause deployment/example-app
+deployment "example-app" image updated
+deployment "example-app" paused
+```
+
+Note that any current state of the `Deployment` will continue its function, but new updates to the `Deployment` will not have an effect as long as the `Deployment` is paused.
+
+The `Deployment` was still in progress when we paused it, so the actions of scaling up and down Replica Sets are paused too.
+
+```
+$kubectl get rs
+NAME                          DESIRED   CURRENT   AGE
+example-app-1564180365   2         2         1h
+example-app-2035384211   2         2         1h
+example-app-3066724191   0         0         1h
+```
+
+To resume the `Deployment`, simply do `kubectl rollout resume`
+
+```
+$kubectl rollout resume deployment/example-app
+deployment "example-app" resumed
+```
+
+Then the `Deployment` will continue and finish the rollout
+
+```
+$ kubectl rollout status deployment/example-app
+Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment spec update to be observed...
+Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
+deployment example-app successfully rolled out
+```
+
+## Check the change history (deployment versions)
+
+To check the revisions of this deployment use `kubectl rollout history`
+
+Because we recorded the command while creating this Deployment using `--record`, we can easily see the changes we made in each revision.
+
+```
+$kubectl rollout history deployment/example-app
+deployments "example-app":
+REVISION    CHANGE-CAUSE
+1           kubectl create -f example-app.deployment.yaml --record
+2           kubectl set image deployment/example-app example-app=quay.io/reactiveops/example-app:1.0.1
+3           kubectl set image deployment/example-app example-app=quay.io/reactiveops/example-app:1.0.1
+```
+
+To see more details for each revision
+
+```
+$ kubectl rollout history deployment/example-app --revision=2
+deployments "example-app" revision 2
+  Labels:       app=example-app
+          pod-template-hash=1159050644
+  Annotations:  kubernetes.io/change-cause=kubectl set image deployment/example-app example-app=quay.io/reactiveops/example-app:1.0.1
+  Containers:
+   example-app:
+    Image:      quay.io/reactiveops/example-app:1.0.1
+    Port:       80/TCP
+     QoS Tier:
+        cpu:      BestEffort
+        memory:   BestEffort
+    Environment Variables:      <none>
+  No volumes.
+
+```
+
+## Rollback to a previous version
+
+To undo a `Deployment` rollout and rollback to the previous revision
+
+```
+$kubectl rollout undo deployment/example-app
+deployment "example-app" rolled back
+```
+
+To rollback to a specific revision by specify that in --to-revision
+
+```
+$ kubectl rollout undo deployment/example-app --to-revision=2
+deployment "example-app" rolled back
+```
+
+The `Deployment` is now rolled back to a previous stable revision. As you can see, a `DeploymentRollback` event for rolling back to revision 2 is generated from `Deployment` controller.
+
+```
+$ kubectl describe deployment 
+Name:           example-app
+Namespace:      default
+CreationTimestamp:  Tue, 22 Nov 2016 13:11:07 -0500
+Labels:         app=example-app
+Selector:       app=example-app
+Replicas:       3 updated | 3 total | 3 available | 0 unavailable
+StrategyType:       RollingUpdate
+MinReadySeconds:    0
+RollingUpdateStrategy:  1 max unavailable, 1 max surge
+OldReplicaSets:     <none>
+NewReplicaSet:      example-app-1564180365 (3/3 replicas created)
+Events:
+  FirstSeen LastSeen    Count   From                    SubobjectPath   Type        Reason              Message
+  --------- --------    -----   ----                    -------------   --------    ------              -------
+  30m       30m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-2035384211 to 3
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-1564180365 to 1
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled down replica set example-app-2035384211 to 2
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-1564180365 to 2
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled down replica set example-app-2035384211 to 0
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-3066724191 to 2
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-3066724191 to 1
+  29m       29m         1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled down replica set example-app-1564180365 to 2
+  2m        2m          1       {deployment-controller }                Normal      ScalingReplicaSet   Scaled down replica set example-app-3066724191 to 0
+  2m        2m          1       {deployment-controller }                Normal      DeploymentRollback  Rolled back deployment "example-app" to revision 2
+  29m       2m          2       {deployment-controller }                Normal      ScalingReplicaSet   Scaled up replica set example-app-1564180365 to 3
+```
+
+
+## Deployment Clean up Policy
+
+Inside your `Deployment` you can set .spec.revisionHistoryLimit field to specify how much revision history of a particular `Deployment` you want to keep. By default, all revision history will be kept; explicitly setting this field to 0 disallows a deployment being rolled back.
+

--- a/lib/pentagon/docs/how-to.md
+++ b/lib/pentagon/docs/how-to.md
@@ -1,0 +1,37 @@
+# HOWTO
+
+## How do I setup my workstation to use kubectl?
+
+See [Installing and Setting up kubectl](setup-kubectl.md)
+
+## How do I choose which cluster to communicate with?
+
+**Staging (v1.4)**
+
+`$ kubectl config use-context staging`
+
+**Production (v1.4)**
+
+`$ kubectl config use-context production`
+
+## How do I onboard an application?
+
+See [Onboard an application](application-lifecycle.md#onboard-an-application)
+
+## How do I deploy an application build?
+
+See [Deploy an application build](application-lifecycle.md#deploy-an-application-build)
+
+## Is there an easy way for me to visualize what is going on?
+
+Each cluster has a UI addon installed and is available via https with the user credentials (username/password) inside the kubeconfig.
+
+**working.k8s.reactiveops.com (v1.4)**
+
+`https://api.working.k8s.reactiveops.com/ui`
+
+**production.k8s.reactiveops.com (v1.4)**
+
+`https://api.production.k8s.reactiveops.com/ui`
+
+**Note**: once connected to the UI of the physical cluster you are interested in, the namespaces (`working`,`production`) are available via a dropdown box on the left-hand side menu.

--- a/lib/pentagon/docs/kubernetes-templates/example-app-production.configmap.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-app-production.configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-app
+  namespace: production
+data:
+  rails_env: "production"
+  rack_env: "production"

--- a/lib/pentagon/docs/kubernetes-templates/example-app-sandbox.configmap.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-app-sandbox.configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-app
+  namespace: sandbox
+data:
+  rails_env: "staging"
+  rack_env: "staging"

--- a/lib/pentagon/docs/kubernetes-templates/example-app.deployment.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-app.deployment.yml
@@ -1,0 +1,65 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: example-app
+  labels:
+    app: example-app
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: example-app
+          imagePullPolicy: Always
+          image: quay.io/reactiveops/example-app:latest
+          resources:
+            limits:
+              memory: 400Mi
+            requests:
+              memory: 400Mi
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          env:
+          # configmaps
+          - name: RAILS_ENV
+            valueFrom:
+              configMapKeyRef:
+                name: example-app
+                key: rails-env
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                name: example-app
+                key: rack-env
+          # secrets
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-super-secret
+                key: database-url
+          # required for in-place redeploy
+          - name: RESTART_
+            value: ""

--- a/lib/pentagon/docs/kubernetes-templates/example-app.service.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-app.service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-app
+  labels:
+    app: example-app
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+  selector:
+    app: example-app

--- a/lib/pentagon/docs/kubernetes-templates/example-worker-production.configmap.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-worker-production.configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-worker
+  namespace: production
+data:
+  rails_env: "production"
+  rack_env: "production"

--- a/lib/pentagon/docs/kubernetes-templates/example-worker-sandbox.configmap.yaml
+++ b/lib/pentagon/docs/kubernetes-templates/example-worker-sandbox.configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-worker
+  namespace: sandbox
+data:
+  rails_env: "staging"
+  rack_env: "staging"

--- a/lib/pentagon/docs/kubernetes-templates/example-worker.deployment.yml
+++ b/lib/pentagon/docs/kubernetes-templates/example-worker.deployment.yml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: example-worker
+  labels:
+    app: example-worker
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: example-worker
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: example-worker
+          imagePullPolicy: Always
+          image: quay.io/reactiveops/example-worker:latest
+          command: 
+            - bundle
+            - exec
+            - rake
+            - jobs:work
+            - --trace
+          resources:
+            limits:
+              memory: 400Mi
+            requests:
+              memory: 400Mi
+            terminationMessagePath: /dev/termination-log
+          env:
+          # configmaps
+          - name: RAILS_ENV
+            valueFrom:
+              configMapKeyRef:
+                name: my-app
+                key: rails-env
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                name: my-app
+                key: rack-env
+          # secrets
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-super-secret
+                key: database-url
+          # required for in-place redeploy
+          - name: RESTART_
+            value: ""

--- a/lib/pentagon/docs/minion-disks.md
+++ b/lib/pentagon/docs/minion-disks.md
@@ -1,0 +1,5 @@
+# Minion Disks
+
+Kubernetes can run out of disk space on individual minions, this is called “[disk pressure](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/)” by Kubernetes. In practice we have not seen Kubernetes react quickly enough to clean up disks before this becomes a problem. 
+
+We've put in 100gb disks for the minions but may increase them. We run [docker-gc](https://github.com/spotify/docker-gc) to help clean up disks proactively instead of as we run out of disk. 

--- a/lib/pentagon/docs/pods.md
+++ b/lib/pentagon/docs/pods.md
@@ -1,0 +1,26 @@
+# Pods
+
+`killing`, `replacing`, `restart` a pod means to terminate it and allow Kubernetes to replace it. There isn’t a way to actually “restart” a pod in Kubernetes.  This can be done in the Dashboard UI via the “Delete” action on a pod or with `kubectl delete pod $POD`.
+
+
+## Liveness 
+
+Strive to have the container exit if the process is broken and allow Kubernetes to replace the pod. 
+
+Use `minReadySeconds` for longer than a normal startup time to make sure Kubernetes doesn’t think startup time counts as successful running time.
+
+Include a `livenessProbe` for web/socket applications. Daemons are a bit harder and benefit from the above-mentioned exiting if things are not working. 
+
+
+## Images
+
+The pod’s `spec.containers[].image` field specifies the image to be used for the pod. It is best to use a tag for the image that will not be re-tagged/reused. `rok8s-scripts` will turn the `latest` tag into the `$CI_SHA1` to help with this. 
+
+Using the `latest` (without `rok8s-scripts`) or any branch tag can lead to problems. Kubernetes will pull images only if they don’t exist already in that Docker instance. If you reused the image you would need to use `imagePullPolicy` to always pull the image, taking more time to roll out the deployment. Without `imagePullPolicy: always` you could run into multiple versions deployed depending on the current version at the time the Kubernetes node first pulled the image. 
+
+Using `latest` in particular can cause problems as `latest` could be from any build, not just `latest` on the `master` branch.
+
+## Multi-Container Pods
+
+Avoid them: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+single container failures could still be a successful pod, which will deploy "successfully"

--- a/lib/pentagon/docs/readme.md
+++ b/lib/pentagon/docs/readme.md
@@ -1,1 +1,0 @@
-insert client-facing docs here

--- a/lib/pentagon/docs/setting-context.md
+++ b/lib/pentagon/docs/setting-context.md
@@ -1,0 +1,99 @@
+# Setting Kubernetes Context
+
+## tl;dr
+
+Global context
+
+>`kubectl config use-context <context>`
+
+Command context
+
+>`--context <context>`
+>
+>`--namespace=<namespace> --cluster=<cluster>`
+
+## Clusters and Namespaces
+
+Since the environment currently plays host to several
+
+physical **clusters**:
+- Kubernetes v1.4.x (kops): `working.k8s.reactiveops.com` 
+- Kubernetes v1.4.x (kops): `production.k8s.reactiveops.com`
+
+and namespaces: 
+- `staging`
+- `production`
+
+it is important to be explicit about which combination you will be interacting with.
+
+On the command line, you can specify Kubernetes context in two ways:
+
+1. use the command `kubectl config use-context CONTEXT_NAME` to set the context for all commands henceforth
+2. append `--namespace` and `--context` flags to each `kubectl` command
+
+The former method is more useful when you will be running many commands within the same context (e.g. troubleshooting a Deployment). The latter is useful when comparing commands across multiple namespaces or clusters (e.g. taking stock of cluster resources used)
+
+## Global Context
+
+The global Kubernetes Config (kubeconfig) is maintained within a file.  
+
+This is usually kept in `~/.kube/config`
+
+but can also be loaded via ENV by `export KUBECONFIG=/path/to/kube/config`.  
+
+This file contains many secrets, including certificates, tokens, usernames and passwords.  It should be treated as high-risk information and handled as securely as possible
+
+The kubeconfig also contains information about `context`.  A context defines a named **cluster**, **user**, **namespace** tuple which is used to send requests to the specified cluster using the provided authentication info and namespace. Each of the three pieces is optional; it is valid to specify a context with only one of cluster, user, namespace, or to specify none.  Unspecified values, or named values that don’t have corresponding entries will be replaced with the default. 
+
+
+### Add a Context
+
+To define or set a context entry in kubeconfig, use `kubectl config set-context`, specify the desired name of the context, as well as the defining features (`--cluster`, `--user` and/or `--namespace`).
+
+Specifying a name that already exists will merge new fields on top of existing values for those fields.
+
+Example:
+
+```
+$kubectl config set-context staging --cluster=working.k8s.reactiveops.com --namespace=staging
+```
+
+### Use a Context
+
+To use an already defined context, run the `kubectl config use-context` command and specify the desired context name.  This will ensure that any `kubectl` commands run from that point forward will be applied that that specific context.
+
+Example:
+
+```
+$kubectl config use-context staging
+```
+
+### Display current Context
+
+To display the current context in use, run `kubectl config current-context`
+
+Example:
+
+```
+$ kubectl config current-context
+staging
+```
+
+## Command Context
+
+Setting the kubectl flag `--namespace` allows you to deploy to a specific virtual cluster you'd like to interact with. Namespaces provide a scope for names. Names of resources need to be unique within a namespace, but not across namespaces. Therefore, you can create the same `Deployment` in multiple namespaces.
+
+Setting the kubectl flag `--cluster` allows you to specify the physical Kubernetes cluster you'd like to interact with. 
+
+Setting the kubectl flag `--context` allows you to directly specify the context (combination of `cluster`, `namespace`, `user`) you'd like to interact with.  See above section for adding/defining new contexts. 
+
+**v1.4 Staging**
+
+>`--context=staging`
+>
+>`--namespace=staging --cluster=working.k8s.reactiveops.com`
+
+**v1.4 Production**
+>`--context=production`
+>
+>`--namespace=production --cluster=production.k8s.reactiveops.com`

--- a/lib/pentagon/docs/setup-kubectl.md
+++ b/lib/pentagon/docs/setup-kubectl.md
@@ -1,0 +1,42 @@
+# Installing and Setting up kubectl
+
+1) Download a precompiled Kubernetes release `kubernetes.tar.gz` from [https://github.com/kubernetes/kubernetes/releases](https://github.com/kubernetes/kubernetes/releases)
+
+`wget https://github.com/kubernetes/kubernetes/releases/download/v1.4.7/kubernetes.tar.gz`
+
+or 
+
+`curl -O https://github.com/kubernetes/kubernetes/releases/download/v1.4.7/kubernetes.tar.gz`
+
+2) Untar Kubernetes release to a useful location (e.g. /src)
+
+`tar -xvzf kubernetes.tar.gz`
+
+3) copy or move `kubectl` into a directory already in PATH (e.g. /usr/local/bin)
+
+OS X
+`$ sudo cp /src/kubernetes/platforms/darwin/amd64/kubectl /usr/local/bin/kubectl`
+
+Linux
+`$ sudo cp /src/kubernetes/platforms/linux/amd64/kubectl /usr/local/bin/kubectl`
+
+4) make `kubectl` executable
+
+`$ sudo chmod +x /usr/local/bin/kubectl`
+
+5) retreive kubeconfig file from ReactiveOps. Either place in `~/.kube/config` or other path of your choosing
+
+```
+$ sudo mkdir -p ~/.kube
+$ cp reactiveops.config ~/.kube/config
+```
+
+If you choose a different path make sure you set an environment variable to mark its location
+
+`$ export KUBECONFIG=/path/to/kube/config`
+
+6) ensure `kubectl` is configured and communicating properly with clusters
+
+`$ kubectl cluster-info`
+
+**Note: this will show the cluster in current context**

--- a/lib/pentagon/docs/weave.md
+++ b/lib/pentagon/docs/weave.md
@@ -1,0 +1,3 @@
+# Weave
+
+Weave runs an overlay network which helps to work around the 50/100 entry limit on AWS route tables.  It adds a bit of complication and is a hard requirement for pods working successfully. There is a `CONN_LIMIT` environment variable used (defaults to 30) which will cause errors when scaling above 30 instances. Be sure to change this limit if you need more than 30 instances . 

--- a/lib/pentagon/docs/x-application-onboarding.md
+++ b/lib/pentagon/docs/x-application-onboarding.md
@@ -1,0 +1,54 @@
+# Adding an application to the Kubernetes system
+
+To setup your application for Kubernetes deployment, you need to accomplish the following high level tasks:
+
+1. Decide on a name for your application. Use this everywhere
+1. Create a Dockerfile
+1. Create an empty ECR repository
+1. Add deploy scripts (`scripts` directory)
+1. Add bin scripts (`bin` directory)
+1. Define your Kubernetes Deployment, Service, and Secret configuration
+1. Create a CircleCI build
+1. Ship a GitHub release (pushes to -> production namespace)
+
+## Step 1: Name your application
+
+Decide on a name for your application and use it everywhere: e.g. GitHub Repo, ECR Repo, Kubernetes config, etc.
+
+## Step 2: Create a Dockerfile
+
+Make sure to use the EXPOSE command in your Dockerfile to specify what port(s) your application
+will be listening on.
+
+## Step 3: Create an empty ECR repository
+
+Create an empty ECR repository under the organization. Then setup permissions:
+* Give `nodes.<cluster>.k8s.reactiveops.com` IAM role R/O permissions
+* Give `circleci` IAM user R/W permissions
+* Give ReactiveOps team R/O permissions
+
+## Step 4: Define your Kubernetes Deployment, Service, and Secret configuration
+
+1. Copy the `kubernetes-templates` directory to the top level path of your application as `deploy`.
+2. Rename the files, replacing 'example-app' with the name of your application (see step 1)
+3. Find-replace 'example-app' with your application name in both files.
+4. Update Service file with port(s) that your Docker application will expose (from Step 2).
+5. Configure a Secret if necessary. If your application requires credentials that are NOT stored in GitHub, then you will need to create a Secret.  See example-app.secret.yml for reference. This file should be uploaded to S3 (with KMS) to com.reactiveops.kubernetes-secrets. If you don't need a Secret, delete the secret file.
+6. Update Deployment file
+  * Specify the port(s) your container will be listening on (from step 2)
+  * Configure liveness/readiness probes with a port/URL that will return 200 if app working correctly
+  * Specify any required environment variables your application needs (e.g. database URL)
+  * Specify any required secret values you need. Can be available via filesystem or environment variable
+
+## Step 7: Create a CircleCI build
+1. Create a CircleCI build for your repository
+2. Setup environment variables in CircleCI UI
+  * KUBECONFIG_DATA=base64(kubeconfig)
+  * AWS_ACCESS_KEY_ID=
+  * AWS_SECRET_ACCESS_KEY=
+  * AWS_DEFAULT_REGION=
+3. Copy circle.yml from `<SOMEWHERE>` to the top-level of your application
+4. Find-replace 'example_app' in circle.yml with your application name.
+
+## Step 9: Ship to production via GitHub Release
+Todo: Doc this

--- a/lib/pentagon/docs/x-services.md
+++ b/lib/pentagon/docs/x-services.md
@@ -1,0 +1,4 @@
+
+# Kubernetes Services
+
+Not all service attributes are updated in Kubernetes after deployment. If that is the case then recreating the resource will be needed. 

--- a/lib/pentagon/docs/x-services.md
+++ b/lib/pentagon/docs/x-services.md
@@ -2,3 +2,13 @@
 # Kubernetes Services
 
 Not all service attributes are updated in Kubernetes after deployment. If that is the case then recreating the resource will be needed. 
+
+## Services and Consul8s
+
+With Consul registration you won't be able to update services atomically. To avoid an outage you must deregister the service from Consul (`deregister: "true"` in service config), then can remove the Kubernetes Service.
+
+[Consul8s](https://github.com/reactiveops/consul8s) is designed to fail instead of swallow errors. This can be dangerous in that it may not keep everything up to date. It will stop before it causes harm though if there is an error.
+
+Consul services with 0 endpoints are an error for consul8s. 
+
+[A Consul8s exit can be used for monitoring](https://github.com/reactiveops/consul8s#monitoring) when `--prometheus` flag is used.


### PR DESCRIPTION
Current Behavior
----------
* End users who have no familiarity with Kubernetes do not have any documentation regarding application lifecycle, resource management, proper usage, etc.

Why Change?
---------
* Provide some basic, generic, useful information regarding creation, usage and management of Kubernetes resources in an application lifecycle.

Implementation Details
------------
* Provide easy, grokable information about different Kubernetes resource types
* Provide runbooks for common ops procedures
* Provide example application templates for easy onboarding
* Provide FAQ or HOWTO articles 

Side Effects
----------
N/A

Documentation
----------
* Self documenting

Metrics
----------
N/A

Run Plan
----------
N/A

