### PR TITLE
default VPC CIDR change

### DIFF
--- a/lib/pentagon/components/vpc/files/variables.tf
+++ b/lib/pentagon/components/vpc/files/variables.tf
@@ -16,7 +16,7 @@ variable "aws_azs" {
 ###
 
 variable "vpc_cidr" {
-  default = "10.10"
+  default = "172.20"
 }
 
 variable "aws_vpc_name" {}

--- a/lib/pentagon/default/vpc/variables.tf
+++ b/lib/pentagon/default/vpc/variables.tf
@@ -16,7 +16,7 @@ variable "aws_azs" {
 ###
 
 variable "vpc_cidr" {
-  default = "10.10"
+  default = "172.20"
 }
 
 variable "aws_vpc_name" {}


### PR DESCRIPTION
We should not use anything in the 10.x address space, it is likely that this would cause routing issues with ClassicLink or EC2 classic, VPC peering or VPN connections.