### PR TITLE
config/local: create `-default` files

### DIFF
--- a/bin/pentagon
+++ b/bin/pentagon
@@ -86,6 +86,10 @@ cli.add_command(start_project, "start-project")
 def next_steps():
     steps = """
 
+# Generate your local configuration
+cd <project_name>-infrastructure/
+./config/local/local-config-init
+
 # S3 buckets will need to be created
 
 # Execute the following steps to create VPC

--- a/lib/pentagon/README.md
+++ b/lib/pentagon/README.md
@@ -46,6 +46,12 @@ source default/account/vars.sh
 
 Per AWS account variables are in `default/account/vars.sh` used for creating the Kubernetes cluster but not needed for most other operations. When creating a cluster the `kops.sh` file
 
+Per user configuration needs to be generated. These files cannot directly use the `$INFRASTRUCTURE_REPO` environment variable for various reasons. The `config/local/local-config-init` script will generate the files needed from templates in that same folder.
+
+```
+./config/local/local-config-init
+```
+
 ### VPC
 
 The VPC Terraform code is in `default/vpc` and has a `Makefile` to help with the commands needed.

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -410,11 +410,10 @@ class PentagonProject():
         return self.__render_template(template_name, template_path, target, context)
 
     def __prepare_ssh_config_vars(self):
-        template_name = "ssh_config.jinja"
+        template_name = "ssh_config-default.jinja"
         template_path = "{}/config/local".format(self._repository_directory)
-        target = "{}/config/local/ssh_config".format(self._repository_directory)
+        target = "{}/config/local/ssh_config-default".format(self._repository_directory)
         context = {
-            'infrastructure_repository': self._repository_directory,
             'production_kube_key': self._ssh_keys['production_kube'],
             'working_kube_key': self._ssh_keys['working_kube'],
             'production_private_key': self._ssh_keys['production_private'],
@@ -424,12 +423,10 @@ class PentagonProject():
         return self.__render_template(template_name, template_path, target, context)
 
     def __prepare_ansible_cfg_vars(self):
-        template_name = "ansible.cfg.jinja"
+        template_name = "ansible.cfg-default.jinja"
         template_path = "{}/config/local".format(self._repository_directory)
-        target = "{}/config/local/ansible.cfg".format(self._repository_directory)
-        context = {
-            'infrastructure_repository': self._repository_directory,
-        }
+        target = "{}/config/local/ansible.cfg-default".format(self._repository_directory)
+        context = {}
         return self.__render_template(template_name, template_path, target, context)
 
     def __prepare_vpn_cfg_vars(self):

--- a/lib/pentagon/config/local/ansible.cfg-default.jinja
+++ b/lib/pentagon/config/local/ansible.cfg-default.jinja
@@ -7,4 +7,4 @@ hash_behavior = merge
 
 [ssh_connection]
 # this needs the path defined wihtout the use of ENV variables
-ssh_args = -F {{ infrastructure_repository }}/config/local/ssh_config
+ssh_args = -F __INFRA_REPO_PATH__/config/local/ssh_config

--- a/lib/pentagon/config/local/ssh_config-default.jinja
+++ b/lib/pentagon/config/local/ssh_config-default.jinja
@@ -1,34 +1,34 @@
 # for the kube / kops working instances
 Host 172.20.64.* 172.20.65.* 172.20.66.* 172.20.67.* 172.20.68.* 172.20.69.* 172.20.70.* 172.20.71.* 172.20.72.* 172.20.73.* 172.20.74.* 172.20.75.*
   User admin
-  IdentityFile {{ infrastructure_repository }}/config/private/{{ working_kube_key }}
+  IdentityFile __INFRA_REPO_PATH__/config/private/{{ working_kube_key }}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 
 # for the kube / kops prod instances
 Host 172.20.96.* 172.20.97.* 172.20.98.* 172.20.99.* 172.20.100.* 172.20.101.* 172.20.102.* 172.20.103.* 172.20.104.* 172.20.105.* 172.20.106.* 172.20.107.*
   User admin
-  IdentityFile {{ infrastructure_repository }}/config/private/{{ production_kube_key }}
+  IdentityFile __INFRA_REPO_PATH__/config/private/{{ production_kube_key }}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 
 # for instances in private_working
 Host 172.20.48.* 172.20.49.* 172.20.50.* 172.20.51.* 172.20.52.* 172.20.53.* 172.20.54.* 172.20.55.* 172.20.56.* 172.20.57.* 172.20.58.* 172.20.59.*
   User ubuntu
-  IdentityFile {{ infrastructure_repository }}/config/private/{{ working_private_key }}
+  IdentityFile __INFRA_REPO_PATH__/config/private/{{ working_private_key }}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 
 # for instances in private_prod
 Host 172.20.32.* 172.20.33.* 172.20.34.* 172.20.35.* 172.20.36.* 172.20.37.* 172.20.38.* 172.20.39.* 172.20.40.* 172.20.41.* 172.20.42.* 172.20.43.*
   User ubuntu
-  IdentityFile {{ infrastructure_repository }}/config/private/{{ production_private_key }}
+  IdentityFile __INFRA_REPO_PATH__/config/private/{{ production_private_key }}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 
 # for instances in admin
 Host 172.20.0.* 172.20.1.* 172.20.2.* 172.20.3.* 172.20.4.* 172.20.5.* 172.20.6.* 172.20.7.* 172.20.8.* 172.20.9.* 172.20.10.* 172.20.11.*
   User ubuntu
-  IdentityFile {{ infrastructure_repository }}/config/private/{{ admin_vpn_key }}
+  IdentityFile __INFRA_REPO_PATH__/config/private/{{ admin_vpn_key }}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null


### PR DESCRIPTION
Create `-default` files that can be used to create per-user config
files. This will allow checking in the `-default` files to share
configuration while still having the per-user configuration needed
for filesystem paths.

Closes #41 

Tested locally that the files are placed correctly and that running `local-config-init` will generate files with the replaced values. 