### PR TITLE
Simplify setup location 

### DIFF
--- a/bin/pentagon
+++ b/bin/pentagon
@@ -15,7 +15,7 @@ def cli():
 @click.argument('name')
 @click.option('-f', '--config-file', help='File to read configuration options from. File supercedes command line options.')
 @click.option('-o', '--output-file', help='File to write options to after completion')
-@click.option('--workspace-directory', help='Directory to place new project, defaults to ~/workspace/')
+@click.option('--workspace-directory', help='Directory to place new project, defaults to ./')
 @click.option('--repository-name', help='Name of the folder to initialize the infrastructure repository')
 @click.option('--configure/--no-configure', default=True, help='Configure project with default settings')
 @click.option('--force/--no-force', help="Ignore existing directories and copy project")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ It is our curated ecosystem of container-based infrastructure based on Kubernete
     * No default
   * **--workspace-directory**:
     * Directory to place new project
-    * Defaults to `~/workspace/`
+    * Defaults to `./`
   * **--repository-name**:
     * Name of the folder to initialize the infrastructure repository
     * Defaults to `<project-name>-infrastructure`

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -475,7 +475,8 @@ class PentagonProject():
 
     def __directory_check(self):
         if not self.__workspace_directory_exists():
-            raise PentagonException("Workspace directory does not exist. Have you set up your workstation?")
+            msg = "Workspace directory `{0}` does not exist.".format(self._workspace_directory)
+            raise PentagonException(msg)
 
     def start(self):
         self.__directory_check()

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -143,10 +143,8 @@ class PentagonProject():
         # Setting local path info
         self._repository_name = os.path.expanduser(self.get_arg("repository_name", "{}-infrastructure".format(name)))
         self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '~/workspace'))
-        self._projects_directory = os.path.expanduser('{}/projects'.format(self._workspace_directory))
-        self._project_directory = os.path.expanduser('{}/projects/{}'.format(self._workspace_directory, self._name))
         self._repository_directory = "{}/{}".format(
-            self._project_directory,
+            self._workspace_directory,
             self._repository_name)
 
         self._private_path = "{}/config/private/".format(self._repository_directory)
@@ -251,12 +249,6 @@ class PentagonProject():
     def __repository_directory_exists(self):
         logging.debug("Verifying repository {}".format(self._repository_directory))
         if os.path.isdir(self._repository_directory):
-            return True
-        return False
-
-    def __projects_directory_exists(self):
-        logging.debug("Verifying projects{}".format(self._projects_directory))
-        if os.path.isdir(self._projects_directory):
             return True
         return False
 
@@ -484,12 +476,6 @@ class PentagonProject():
     def __directory_check(self):
         if not self.__workspace_directory_exists():
             raise PentagonException("Workspace directory does not exist. Have you set up your workstation?")
-
-        if not self.__projects_directory_exists():
-            raise PentagonException("Projects directory does not exist. Have you set up your workstation?")
-
-        if not self.__project_directory_exists():
-            raise PentagonException("Project path does not exist. Have you created your project yet?")
 
     def start(self):
         self.__directory_check()

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -142,7 +142,7 @@ class PentagonProject():
 
         # Setting local path info
         self._repository_name = os.path.expanduser(self.get_arg("repository_name", "{}-infrastructure".format(name)))
-        self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '~/workspace'))
+        self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '.'))
         self._repository_directory = "{}/{}".format(
             self._workspace_directory,
             self._repository_name)
@@ -249,12 +249,6 @@ class PentagonProject():
     def __repository_directory_exists(self):
         logging.debug("Verifying repository {}".format(self._repository_directory))
         if os.path.isdir(self._repository_directory):
-            return True
-        return False
-
-    def __project_directory_exists(self):
-        logging.debug("Verifying project {}".format(self._project_directory))
-        if os.path.isdir(self._project_directory):
             return True
         return False
 

--- a/lib/tests/test_base.py
+++ b/lib/tests/test_base.py
@@ -25,16 +25,10 @@ class TestPentagonProject(unittest.TestCase):
         self.assertEqual(self.p._repository_name, '{}-infrastructure'.format(self.name))
 
     def test_repository_directory(self):
-        self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._project_directory, self.p._repository_name))
+        self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._workspace_directory, self.p._repository_name))
 
     def test_workspace_directory(self):
         self.assertEqual(self.p._workspace_directory, os.path.expanduser('~/workspace'))
-
-    def test_projects_directory(self):
-        self.assertEqual(self.p._projects_directory, '{}/projects'.format(self.p._workspace_directory))
-
-    def test_project_directory(self):
-        self.assertEqual(self.p._project_directory, '{}/projects/{}'.format(self.p._workspace_directory, self.p._name))
 
     def test_private_path(self):
         self.assertEqual(self.p._private_path, "{}/config/private/".format(self.p._repository_directory))

--- a/lib/tests/test_base.py
+++ b/lib/tests/test_base.py
@@ -28,7 +28,7 @@ class TestPentagonProject(unittest.TestCase):
         self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._workspace_directory, self.p._repository_name))
 
     def test_workspace_directory(self):
-        self.assertEqual(self.p._workspace_directory, os.path.expanduser('~/workspace'))
+        self.assertEqual(self.p._workspace_directory, os.path.expanduser('.'))
 
     def test_private_path(self):
         self.assertEqual(self.p._private_path, "{}/config/private/".format(self.p._repository_directory))


### PR DESCRIPTION
Ref #14 

Simplify the location by creating the repository in the workspace directory directly. Could be updated to default to the current directory instead of `~/workspace`

Also includes updating the error message to say which folder is needed but doesn't exist in order to be a bit more helpful. 