### PR TITLE
Include requirements for generated infrastructure repository

### DIFF
--- a/lib/pentagon/README.md
+++ b/lib/pentagon/README.md
@@ -15,9 +15,7 @@ kubectl should try to match the cluster version, in this case the 1.5.x series f
 
 Python Libraries:
 
-Libraries required are installed as part of [Pentagon](https://github.com/reactiveops/pentagon)
-
-This can be installed into a [virtualenv](https://virtualenv.pypa.io/en/stable/) to isolate the installtion from your system.
+Libraries required can be installed with `pip install -r requirements.txt`. These can be installed into a [virtualenv](https://virtualenv.pypa.io/en/stable/) to isolate the installation from your system.
 
 ### Shell environment
 

--- a/lib/pentagon/requirements.txt
+++ b/lib/pentagon/requirements.txt
@@ -1,0 +1,4 @@
+boto3==1.4.4
+ansible==2.3.0.0
+shyaml==0.5.0
+awscli==1.11.122

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Changes here may need to be updated in setup.py and lib/pentagon/requirements.txt as well
 backports-abc==0.4
 certifi==2016.9.26
 cffi==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(name='pentagon',
       author_email='reactive@reactiveops.com',
       url='http://reactiveops.com/',
       license='GPLv3',
+
+      # Changes to requirements here may need to be updated in
+      # lib/pentagon/requirements.txt and requirements.txt as well
       install_requires=[
         "click==6.7",
         "GitPython==2.1.3",


### PR DESCRIPTION
`requirements.txt` is needed for the resulting repository where users may not have Pentagon, or the matching version of Pentagon, installed. 

This unfortunately creates another list of packages to install. I don't know if we have a guideline for what needs to go where or what is used/useful for the current `requirements.txt in the root of this repo. 