### PR TITLE
tasks: Remove dependency install script

### DIFF
--- a/lib/pentagon/tasks/install-dependencies.sh
+++ b/lib/pentagon/tasks/install-dependencies.sh
@@ -1,6 +1,0 @@
-#/bin/bash
-
-# stub / pseudocode
-if OS = OSX
-  brew install kops
-  brew install terraform


### PR DESCRIPTION
Per discussion in #31 

Remove an incomplete install script in favor of documentation. The
script only handles a couple requirements for OSX while installing
versions that are likely incompatible with what Pentagon requires.

Documented already in https://github.com/reactiveops/pentagon/blob/1bcc1e1e1b49fd5d9f01d2293d9674558e1b2e4c/lib/pentagon/README.md#system-requirements

