### PR TITLE
Defaulting Pentagon Workspace to local directory

### DIFF
--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -475,7 +475,8 @@ class PentagonProject():
 
     def __directory_check(self):
         if not self.__workspace_directory_exists():
-            raise PentagonException("Workspace directory does not exist. Have you set up your workstation?")
+            msg = "Workspace directory `{0}` does not exist.".format(self._workspace_directory)
+            raise PentagonException(msg)
 
     def start(self):
         self.__directory_check()

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -143,10 +143,8 @@ class PentagonProject():
         # Setting local path info
         self._repository_name = os.path.expanduser(self.get_arg("repository_name", "{}-infrastructure".format(name)))
         self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '~/workspace'))
-        self._projects_directory = os.path.expanduser('{}/projects'.format(self._workspace_directory))
-        self._project_directory = os.path.expanduser('{}/projects/{}'.format(self._workspace_directory, self._name))
         self._repository_directory = "{}/{}".format(
-            self._project_directory,
+            self._workspace_directory,
             self._repository_name)
 
         self._private_path = "{}/config/private/".format(self._repository_directory)
@@ -251,12 +249,6 @@ class PentagonProject():
     def __repository_directory_exists(self):
         logging.debug("Verifying repository {}".format(self._repository_directory))
         if os.path.isdir(self._repository_directory):
-            return True
-        return False
-
-    def __projects_directory_exists(self):
-        logging.debug("Verifying projects{}".format(self._projects_directory))
-        if os.path.isdir(self._projects_directory):
             return True
         return False
 
@@ -484,12 +476,6 @@ class PentagonProject():
     def __directory_check(self):
         if not self.__workspace_directory_exists():
             raise PentagonException("Workspace directory does not exist. Have you set up your workstation?")
-
-        if not self.__projects_directory_exists():
-            raise PentagonException("Projects directory does not exist. Have you set up your workstation?")
-
-        if not self.__project_directory_exists():
-            raise PentagonException("Project path does not exist. Have you created your project yet?")
 
     def start(self):
         self.__directory_check()

--- a/lib/pentagon/__init__.py
+++ b/lib/pentagon/__init__.py
@@ -142,7 +142,7 @@ class PentagonProject():
 
         # Setting local path info
         self._repository_name = os.path.expanduser(self.get_arg("repository_name", "{}-infrastructure".format(name)))
-        self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '~/workspace'))
+        self._workspace_directory = os.path.expanduser(self.get_arg('workspace_directory', '.'))
         self._repository_directory = "{}/{}".format(
             self._workspace_directory,
             self._repository_name)
@@ -249,12 +249,6 @@ class PentagonProject():
     def __repository_directory_exists(self):
         logging.debug("Verifying repository {}".format(self._repository_directory))
         if os.path.isdir(self._repository_directory):
-            return True
-        return False
-
-    def __project_directory_exists(self):
-        logging.debug("Verifying project {}".format(self._project_directory))
-        if os.path.isdir(self._project_directory):
             return True
         return False
 

--- a/lib/tests/test_base.py
+++ b/lib/tests/test_base.py
@@ -25,16 +25,10 @@ class TestPentagonProject(unittest.TestCase):
         self.assertEqual(self.p._repository_name, '{}-infrastructure'.format(self.name))
 
     def test_repository_directory(self):
-        self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._project_directory, self.p._repository_name))
+        self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._workspace_directory, self.p._repository_name))
 
     def test_workspace_directory(self):
         self.assertEqual(self.p._workspace_directory, os.path.expanduser('~/workspace'))
-
-    def test_projects_directory(self):
-        self.assertEqual(self.p._projects_directory, '{}/projects'.format(self.p._workspace_directory))
-
-    def test_project_directory(self):
-        self.assertEqual(self.p._project_directory, '{}/projects/{}'.format(self.p._workspace_directory, self.p._name))
 
     def test_private_path(self):
         self.assertEqual(self.p._private_path, "{}/config/private/".format(self.p._repository_directory))

--- a/lib/tests/test_base.py
+++ b/lib/tests/test_base.py
@@ -28,7 +28,7 @@ class TestPentagonProject(unittest.TestCase):
         self.assertEqual(self.p._repository_directory, "{}/{}".format(self.p._workspace_directory, self.p._repository_name))
 
     def test_workspace_directory(self):
-        self.assertEqual(self.p._workspace_directory, os.path.expanduser('~/workspace'))
+        self.assertEqual(self.p._workspace_directory, os.path.expanduser('.'))
 
     def test_private_path(self):
         self.assertEqual(self.p._private_path, "{}/config/private/".format(self.p._repository_directory))


### PR DESCRIPTION
defaulting pentagon start project to in the current directory. --work…space-directory can still be used to target the repository.