### PR TITLE
Small ansible changes

### DIFF
--- a/lib/pentagon/config/local/ansible.cfg-default.jinja
+++ b/lib/pentagon/config/local/ansible.cfg-default.jinja
@@ -6,5 +6,5 @@ retry_files_save_path = ~/.ansible-retry
 hash_behavior = merge
 
 [ssh_connection]
-# this needs the path defined wihtout the use of ENV variables
+# this needs the path defined without the use of ENV variables
 ssh_args = -F __INFRA_REPO_PATH__/config/private/ssh_config

--- a/lib/pentagon/config/local/ansible.cfg-default.jinja
+++ b/lib/pentagon/config/local/ansible.cfg-default.jinja
@@ -1,6 +1,6 @@
 [defaults]
 inventory = $INFRASTRUCTURE_REPO/plugins/inventory
-roles_path = $INFRASTRUCTURE_REPO/roles:$INFRASTRUCTURE_REPO/roles
+roles_path = $INFRASTRUCTURE_REPO/../roles:$INFRASTRUCTURE_REPO/roles
 filter_plugins = $INFRASTRUCTURE_REPO/plugins/filter_plugins
 retry_files_save_path = ~/.ansible-retry
 hash_behavior = merge


### PR DESCRIPTION
Store the roles outside the repo by default. This was changed in f78132b6 but did not include a description of why this change was made.

The path was then duplicated which leads me to think it was maybe not intentional. If we are going to start vendoring of roles we should call that out explicitly.