### PR TITLE
vpc: Output VPC variables

### DIFF
--- a/pentagon/component/vpc/files/main.tf.jinja
+++ b/pentagon/component/vpc/files/main.tf.jinja
@@ -40,3 +40,29 @@ terraform {
     region = "{{ aws_region }}"
   }
 }
+
+// Output VPC values to allow this statefile to be used as a datasource
+
+output "aws_vpc_subnet_admin_ids" {
+  value = "${module.vpc.aws_subnet_admin_ids}"
+}
+
+output "aws_vpc_subnet_private_working_ids" {
+  value = "${module.vpc.aws_subnet_private_working_ids}"
+}
+
+output "aws_vpc_subnet_private_prod_ids" {
+  value = "${module.vpc.aws_subnet_private_prod_ids}"
+}
+
+output "aws_vpc_subnet_public_ids" {
+  value = "${module.vpc.aws_subnet_public_ids}"
+}
+
+output "aws_vpc_id" {
+  value = "${module.vpc.aws_vpc_id}"
+}
+
+output "aws_vpc_cidr" {
+  value = "${module.vpc.aws_vpc_cidr}"
+}


### PR DESCRIPTION
This allows the state file generated by this TF config to be used as a remote data source. Remote data source can reduce duplication and copying of these values

Closes #59 

This was used with a client that needed these things.