### PR TITLE
Fix VPN instance nameing collision

### DIFF
--- a/lib/pentagon/default/resources/admin-environment/env.yml.jinja
+++ b/lib/pentagon/default/resources/admin-environment/env.yml.jinja
@@ -1,5 +1,7 @@
 ---
-env: admin
+{% raw -%}
+env: "admin-{{ org_name }}"
+{%- endraw %}
 aws_key_name: '{{ admin_vpn_key }}'
 default_ami: '{{ vpn_ami_id }}'
 


### PR DESCRIPTION
add org name to vpn env variable to avoid naming collisions when two vpn instances are in the same VPC