### PR TITLE
Correct Ansible config file for install_requirements target

### DIFF
--- a/lib/pentagon/Makefile
+++ b/lib/pentagon/Makefile
@@ -12,9 +12,10 @@ all: local_config_init install_requirements vpc vpc_id nat_gateways configure_wo
 destroy: destroy_vpn destroy_vpn_bucket destroy_working_cluster destroy_production_cluster destroy_vpc destroy_vpc_bucket
 
 install_requirements:
+	export INFRASTRUCTURE_REPO=$(INFRASTRUCTURE_REPO); \
 	source yaml_source config/local/vars.yml; \
 	pip install -r requirements.txt; \
-	ansible-galaxy install -r ansible-requirements.yml -p roles;
+	ansible-galaxy install -r ansible-requirements.yml;
 
 local_config_init:
 	export INFRASTRUCTURE_REPO=$(INFRASTRUCTURE_REPO); \

--- a/lib/pentagon/Makefile
+++ b/lib/pentagon/Makefile
@@ -14,7 +14,7 @@ destroy: destroy_vpn destroy_vpn_bucket destroy_working_cluster destroy_producti
 install_requirements:
 	source yaml_source config/local/vars.yml; \
 	pip install -r requirements.txt; \
-	ansible-galaxy install -r ansible-requirements.yml;
+	ansible-galaxy install -r ansible-requirements.yml -p roles;
 
 local_config_init:
 	export INFRASTRUCTURE_REPO=$(INFRASTRUCTURE_REPO); \


### PR DESCRIPTION
This ensures that the roles will be installed in `./roles` rather than `/etc/ansible/roles` when `make install_requirements` is run without previously running `make local_config_init`

