### PR TITLE
Clarifying Documentation

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -20,24 +20,24 @@ Options:
 
 ### gcp.cluster
 
-- add: 
+- add:
     - Creates `./<cluster_name>/create_cluster.sh` compiled from the data passed in.
     - `bash ./<cluster_name>/create_cluster.sh` will create the cluster as configured.
     - Argument keys are lower case, underscore separated version of the [gcloud container cluster create](https://cloud.google.com/sdk/gcloud/reference/beta/container/clusters/create) command.
     - If a `-f` file is passed in, data are merged with `-D` values ovveriding the file values.
-    - Example: 
+    - Example:
         ```
         pentagon --log-level=DEBUG add  gcp.cluster -D cluster_name="reactiveopsio-cluster" -D project="reactiveopsio" -D network="temp-network" -o ./demo -D node_locations="us-central1-a,us-central1-b" -D zone=us-central1-a
         ```
 
-- get: 
+- get:
     - Creates `./<cluster_name>/create_cluster.sh` by querying the state of an existing cluster and parsing values. For when you have an existing cluster that you want to capture its configuration.
     - Creates `./<cluster_name>/node_pools/<node_pool_name>/create_nodepool.sh` for any nodepools that are not named `default-pool`. Set `-D get_default_nodepools=true` to capture configuration of `default-pool`. This is typically unecessary as the `create_cluster.sh` will already contain the configuration of the `default-pool`
     - `bash ./<cluster_name>/create_cluster.sh` will result in an error indicating the cluster is already present.
     - Argument keys are lower case, underscore separated version of the [gcloud container cluster describe](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/describe) command.
     - If `-f` file is passed in, data are merged with `-D` values ovveriding the file values
     - If `cluster` is omitted it will act on all clusters in the project
-    - Example: 
+    - Example:
       ```
       pentagon get gcp.cluster -D project="pentagon" -D zone="us-central1-a -D cluster="pentagon-1" -D get_default_nodepool="true"
       ```
@@ -49,14 +49,14 @@ Options:
     - `bash ./<nodepool_name>/create_nodepool.sh` will create the nodepool as configured
     - Argument keys are lower case, underscore separated version of the [gcloud container node-pools create](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/create) command
     - If a `-f` file is passed in, data are merged with `-D` values ovveriding the file values
-    - Example: 
+    - Example:
       ```
       pentagon add gcp.nodepool -D name="pentagon-1-nodepool" -D project="pentagon" -D zone="us-central1-a" -D additional_zones="us-central1-b,us-central1-b" -D machine_type="n1-standard-64" --enable-autoscaling
       ```
 
-- get: 
+- get:
     - Creates `./<nodepool_name>/create_nodepool.sh` by querying the state of an existing cluster nodepool and parsing values. For when you have an existing cluster that you want to capture its configuration.
-    - Creates `./<nodepool_name>/create_nodepool.sh` 
+    - Creates `./<nodepool_name>/create_nodepool.sh`
     - `bash ./<nodepool_name>/create_nodepool.sh` will result in an error indicating the cluster is already present.
     - Argument keys are lower case, underscore separated version of the [gcloud container node-pools describe](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/describe) command
     - If a `-f` file is passed in, data are merged with `-D` values ovveriding the file values
@@ -69,7 +69,7 @@ Options:
 
 ### vpc
 
-- add: 
+- add:
     - Creates `./vpc/` directory with Terraform code for the Pentagon default AWS VPC described [here](#network).
     - `cd ./vpc; make all` will create the vpc as describe by the arguments passed in
     - In the normal course of using Pentagon and the infrastructure repository, it is unlikely you'll use this component as it is automatically installed by default.
@@ -85,10 +85,10 @@ Options:
         ```
         pentagon add vpc -D vpc_name="pentagon-vpc" -D vpc_cidr_base="172.20" -D aws_availability_zones="ap-northeast-1a, ap-northeast-1c" -D aws_availability_zone_count = "2" -D aws_region = "ap-northeast-1"
         ```
-        
+
 ### kops.cluster
 
-- add: 
+- add:
     - Creates yml files in  `./<cluster_name>/` compiled from the data passed in.
     - `bash ./<cluster_name>/kops.sh` will create the cluster as configured.
     - Argument/ ConfigFile keys:
@@ -108,7 +108,7 @@ Options:
       - `ssh_key_path`: Path of public key for ssh access to nodes. (required)
       - `network_cidr`: VPC cidr for Kops created Kubernetes subnetes (default: 172.0.0.0/16)
       - `network_cidr_base`: First two octects of the network to template subnet cidrs from  (default: 172.0)
-      - `third_octet`: Starting value for the third octet of the subnet cidrs (default: 16) 
+      - `third_octet`: Starting value for the third octet of the subnet cidrs (default: 16)
       - `network_mask`: Value for network mask in subnet cidrs (defalt: 24)
       - `third_octet_increment`: Increment to increase third octet by for each of the Kubernetes subnets (default: 1) By default, the cidr of the first three private subnets will be 172.20.16.0/24, 172.20.17.0/24, 172.20.18.0/24
       - `authorization`: Authorization type for cluster. Allowed values are `alwaysAllow` and `rbac` (default: alwaysAllow)
@@ -149,18 +149,18 @@ Options:
       - nat-08806276217bae9b5
     ```
     - If a `-f` file is passed in, data are merged with `-D` values overiding the file values.
-    - Example: 
+    - Example:
         ```
         pentagon --log-level=DEBUG add kops.cluster -f `pwd`/vars.yml
         ```
-- get: 
+- get:
     - Creates yml files in `./<cluster_name>/create_cluster.sh` by querying the state of an existing cluster and parsing values. For when you have an existing cluster that you want to capture its configuration.
     - Creates `./<cluster_name>/cluster.yml`, `./<cluster_name>/nodes.yml`, `./<cluster_name>/master.yml`, `./<cluster_name>/secret.sh`
     - `secret.sh` does not have the content of the secret and will be able re-create the cluster secret if needed. You will have to transform the key id into a saved public key.
     - Arguments:
       - `name`: Kops cluster name you are getting (required). Argument can also be set through and environment variable called "CLUSTER_NAME".
       - `kops_state_store_bucket`: s3 bucket name where cluster state is stored (required). Argument can also be set through and environment variable called "KOPS_STATE_STORE_BUCKET"
-    - Example: 
+    - Example:
       ```
       pentagon get kops.cluster -Dname=working-1.cluster.reactiveops.io -Dkops_state_store=reactiveops.io-infrastructure
       ```
@@ -170,7 +170,7 @@ Options:
     - Creates account configuration directory. Creates all necessary files in `config`, `clusters` and `resources`. Depending on `type` it may also add a `vpc` component and `vpn` component under `resources`. Creates `clusters` directory but does not create cluster configuration. Use the cluster component for that.
     - Arguments:
       - `name`: name of account to add to inventory (required)
-      - `type`: type of account to add to inventory aws or gcp (required). 
+      - `type`: type of account to add to inventory aws or gcp (required).
     - If a `-f` file is passed in, data are merged with `-D` values ovveriding the file values
 
 ## Writing your own components
@@ -193,8 +193,8 @@ Examples of plugin component package module name and use:
     *  command: `pentagon add kops.cluster`
     *  module path:  `pentagon_kops.kops`
     *  class: `Cluster()`
-    
 
-See [example](/example-component) 
+
+See [example](/example-component)
 
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -151,7 +151,7 @@ Options:
     - If a `-f` file is passed in, data are merged with `-D` values overiding the file values.
     - Example: 
         ```
-        pentagon add kops.cluster -f `pwd`/vars.yml --log-level=DEBUG
+        pentagon --log-level=DEBUG add kops.cluster -f `pwd`/vars.yml
         ```
 - get: 
     - Creates yml files in `./<cluster_name>/create_cluster.sh` by querying the state of an existing cluster and parsing values. For when you have an existing cluster that you want to capture its configuration.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Pentagon is “batteries included”- not only does one get a network with a clu
 * `pentagon start-project <project-name> --aws-access-key <aws-access-key> --aws-secret-key <aws-secret-key> --aws-default-region <aws-default-region>`
 ### Create a GCP/GKE Pentagon Project
 * `pentagon --log-level=DEBUG start-project --cloud=gcp  <project-name> --gcp-zones=<zone_1>,<zone_2>,..,<zone_n> --gcp-project <gcp_project_name> --gcp-region <gcp_region>`
-### 
+###
 * With the above basic options set, defaults will be set for you. See [Advanced Project Initialization](#advanced-project-initialization) for more options.
   * Arguments may also be set using environment variable in the format `PENTAGON_<argument_name_with_underscores>`.
 * `cd <project-name>-infrastructure`
@@ -45,10 +45,10 @@ Pentagon is “batteries included”- not only does one get a network with a clu
 
 #### Manual steps
 * `pip install -r requirements.txt`
-* `. yaml_source config/local/vars.yml`
-* `. yaml_source config/private/secrets.yml`
+* `. yaml_source inventory/default/config/local/vars.yml`
+* `. yaml_source inventory/default/config/private/secrets.yml`
   * Sources environment variables required for the following steps. This will be required each time you work with the infrastructure repository or if you move the repository to another location.
-* `bash config/local/local-config-init`
+* `bash inventory/default/config/local/local-config-init`
 
 ## AWS
 
@@ -275,8 +275,8 @@ If you wish to utilize the templating ability of the `pentagon start-project` co
     * Google Cloud Project to create clusters in
     * This argument required when --cloud=gcp
   * **--gcp-zones**
-    * Google Cloud Project zones to create clusters in. Comma separated list. 
+    * Google Cloud Project zones to create clusters in. Comma separated list.
     * This argument required when --cloud=gcp
   * **--gcp-region**
-    * Google Cloud region to create resoures in. 
+    * Google Cloud region to create resoures in.
     * This argument required when --cloud=gcp

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Pentagon is “batteries included”- not only does one get a network with a clu
 
 ## Quick Start
 ### Create a AWS Pentagon Project
-* `pentagon start-project <project-name> --aws-access-key <aws-access-key> --aws-secret-key <aws-secret-key> --aws-default-region <aws-default-region>`
+* `pentagon start-project <project-name> --aws-access-key <aws-access-key> --aws-secret-key <aws-secret-key> --aws-default-region <aws-default-region>` --dns-zone <your-dns-zone>
 ### Create a GCP/GKE Pentagon Project
 * `pentagon --log-level=DEBUG start-project --cloud=gcp  <project-name> --gcp-zones=<zone_1>,<zone_2>,..,<zone_n> --gcp-project <gcp_project_name> --gcp-region <gcp_region>`
 ###
@@ -62,7 +62,6 @@ This creates the VPC and private, public, and admin subnets in that VPC for non 
 ### Configure DNS and Route53
 If you don't already have a Route53 Hosted Zone configured, do that now.
 * Create a Route53 Hosted Zone (e.g. `pentagon.mycompany.com`)
-* In `inventory/default/count/vars.yml` set `canonical_zone` to match your Hosted Zone
 * In `inventory/default/clusters/*/vars.yml`
   * Set `CLUSTER_NAME` to a hostname that ends with your hosted zone (e.g. `working-1.pentagon.mycompany.com`)
   * Set `DNS_ZONE` to your Hosted Zone (e.g. `pentagon.mycompany.com`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,7 +89,7 @@ Pentagon uses Kops to create clusters in AWS. The default layout creates configu
 * Use the [Kops component](components.md#kopscluster) to create your cluster.
 * By default a `vars.yml` will be created at `inventory/default/clusters/working` and `inventory/default/clusters/production`. Those files are sufficient to create a cluster using the kops.cluster though, if you are not using `make all` from above you will need to enter `nat_gateways` and `vpc-id` as described in [kops component documentation](components.md#kopscluster)
 
-* To create the cluster configs run `pentagon --log-level=DEBUG add kops.cluster -f vars.yml` in the directory of the cluster you wish to create.
+* To generate the cluster configs run `pentagon --log-level=DEBUG add kops.cluster -f vars.yml` in the directory of the cluster you wish to create.
 * To actually create the cluster: `cd clusters` then `kops.sh`
 * Use [kops](https://github.com/kubernetes/kops/blob/master/docs/cli/kops.md) to manage the cluster if necessary.
   * Run `kops edit cluster <clustername>` to view or edit the `cluster.spec`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,16 +78,19 @@ This creates a AWS instance running [OpenVPN](https://openvpn.net/). Read more a
   * Edit `inventory/config/private/ssh_config` and add the IP address from the SSH key prompt to the `#VPN instance` section.
 
 ### Configure a Kubernetes Cluster
-Pentagon used Kops to create clusters in AWS. The default layout creates configurations for two Kubernetes clusters: `working` and `production`. See [Overview](overview.md) for a more comprehensive description of the directory layout.
+Pentagon uses Kops to create clusters in AWS. The default layout creates configurations for two Kubernetes clusters: `working` and `production`. See [Overview](overview.md) for a more comprehensive description of the directory layout.
 
 * Make sure your KOPS variables are set correctly with `. yaml_source inventory/default/config/local/vars.yml && . yaml_source inventory/default/config/private/secrets.yml`
 * Move into to the path for the cluster you want to work on with `cd inventory/default/clusters/<production|working>`
-* If you are using the `aws_vpc` Terraform provided, ensure you have set `nat_gateways` in the `vars.yml` for each cluster and that they the order of the `nat_gateway` ids matches the order of the subnets listed. This will ensure that the Kops cluster will have a properly configured network with the private subnets associated to the existing NAT gateways.
+* If you are using the `aws_vpc` Terraform provided, ensure you have set `nat_gateways` in the `vars.yml` for each cluster and that they the order of the `nat_gateway` ids matches the order of the subnets listed. This will ensure that the Kops cluster will have a properly configured network with the private subnets associated to the existing NAT gateways.  
+* You can do this using the Makefile `make vpc_id` and `make nat_gateways`.
 
 ### Create Kubernetes Cluster
 * Use the [Kops component](components.md#kopscluster) to create your cluster.
 * By default a `vars.yml` will be created at `inventory/default/clusters/working` and `inventory/default/clusters/production`. Those files are sufficient to create a cluster using the kops.cluster though, if you are not using `make all` from above you will need to enter `nat_gateways` and `vpc-id` as described in [kops component documentation](components.md#kopscluster)
 
+* To create the cluster configs run `pentagon --log-level=DEBUG add kops.cluster -f vars.yml` in the directory of the cluster you wish to create.
+* To actually create the cluster: `cd clusters` then `kops.sh`
 * Use [kops](https://github.com/kubernetes/kops/blob/master/docs/cli/kops.md) to manage the cluster if necessary.
   * Run `kops edit cluster <clustername>` to view or edit the `cluster.spec`
   * You may also wish to edit the instance groups prior to cluster creation:

--- a/pentagon/component/aws_vpc/files/aws_vpc_variables.tf
+++ b/pentagon/component/aws_vpc/files/aws_vpc_variables.tf
@@ -4,8 +4,6 @@ variable "aws_secret_key" {}
 variable "aws_region" {}
 variable "aws_azs" {}
 
-variable "vpc_cidr" {}
-
 variable "aws_vpc_name" {}
 
 variable "az_count" {}


### PR DESCRIPTION
As I go through this getting-started I am going to clarify some small points in the documentation. 

Removing deprecated vpc_cidr from the vpc terraform.

Also, removing trailing spaces.