### PR TITLE
Fix kubernetes_version config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `kubernetes_version` parameter value wasn't applying to the kops cluster config from `values.yml` file
+
 ## [2.3.1] - 2018-5-30
 
 ### Fixed

--- a/pentagon/component/kops/files/cluster.yml.jinja
+++ b/pentagon/component/kops/files/cluster.yml.jinja
@@ -31,7 +31,7 @@ spec:
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: {{ version }}
+  kubernetesVersion: {{ kubernetes_version }}
   masterPublicName: api.{{ cluster_name }}
   networkCIDR: {{ network_cidr }}
   {%- if vpc_id %}
@@ -57,7 +57,7 @@ spec:
     name: utility-{{ az }}
     type: Utility
     zone: {{ az }}
-  {%- endfor %}  
+  {%- endfor %}
   topology:
     dns:
       type: Public

--- a/pentagon/defaults.py
+++ b/pentagon/defaults.py
@@ -17,7 +17,7 @@ class AWSPentagonDefaults(object):
         'node_root_volume_size': 200,
         'v_log_level': 10,
         'network_cidr': '172.20.0.0/16',
-        'version': '1.8.4',
+        'kubernetes_version': '1.8.4',
         'network_mask': 24,
         'third_octet': 16,
         'production_third_octet': 16,

--- a/pentagon/defaults.py
+++ b/pentagon/defaults.py
@@ -17,7 +17,7 @@ class AWSPentagonDefaults(object):
         'node_root_volume_size': 200,
         'v_log_level': 10,
         'network_cidr': '172.20.0.0/16',
-        'kubernetes_version': '1.8.4',
+        'kubernetes_version': '1.9.9',
         'network_mask': 24,
         'third_octet': 16,
         'production_third_octet': 16,

--- a/pentagon/pentagon.py
+++ b/pentagon/pentagon.py
@@ -173,10 +173,10 @@ class AWSPentagonProject(PentagonProject):
         self._vpc_id = self.get_data('vpc_id', self._vpc_id)
 
         # DNS
-        self._dns_zone = self.get_data('dns_zone', '{}.com'.format(self._name))      
+        self._dns_zone = self.get_data('dns_zone', '{}.com'.format(self._name))
 
         # Kubernetes version
-        self._kubernetes_version = self.get_data('kubernetes_version', self.PentagonDefaults.kubernetes['version'])
+        self._kubernetes_version = self.get_data('kubernetes_version', self.PentagonDefaults.kubernetes['kubernetes_version'])
 
         # Working Kubernetes
         self._working_kubernetes_cluster_name = self.get_data('working_kubernetes_cluster_name', 'working-1.{}'.format(self._dns_zone))
@@ -248,7 +248,7 @@ class AWSPentagonProject(PentagonProject):
             'availability_zones': re.sub(" ", "", self._aws_availability_zones).split(","),
             'vpc_id': self._vpc_id,
             'ssh_key_path': "${{INFRASTRUCTURE_REPO}}/{}/{}.pub".format(self._private_path, self._ssh_keys['working_kube_key']),
-            'version': self._kubernetes_version,
+            'kubernetes_version': self._kubernetes_version,
             'ig_max_size': self._working_kubernetes_node_count,
             'ig_min_size': self._working_kubernetes_node_count,
             'master_availability_zones': [zone.strip() for zone in self._working_kubernetes_master_aws_zones.split(',')],


### PR DESCRIPTION
The `kubernetes_version` config parameter in the kops component wasn't actually populating from `vars.yml` variable sourcing. This gets it working and makes the default and parameter names consistent.