### PR TITLE
Adjusted this to be more migratable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Updated
 - replaced PyYaml with oyaml and added capability to have multidocument yaml files for component declarations
+- Kops cluster `authorization` default changed to rbac
+- Updated the inventory config to refer to `${INVENTORY}` vs assigning the `{{name}}` statically. `pentagon/component/inventory/files/common/config/local/vars.yml.jinja`
 
 ### Fixed
 - `kubernetes_version` parameter value wasn't applying to the kops cluster config from `values.yml` file
-
-### Updated
-- Kops cluster `authorization` default changed to rbac
 
 ## [2.3.1] - 2018-5-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.4.0] - 2018-8-21
 
 ### Updated
 - replaced PyYaml with oyaml and added capability to have multidocument yaml files for component declarations

--- a/pentagon/component/inventory/files/common/config/local/vars.yml.jinja
+++ b/pentagon/component/inventory/files/common/config/local/vars.yml.jinja
@@ -1,6 +1,5 @@
-
-ANSIBLE_CONFIG: '${INFRASTRUCTURE_REPO}/inventory/{{ name }}/config/private/ansible.cfg'
-KUBECONFIG: '${INFRASTRUCTURE_REPO}/inventory/{{ name }}/config/private/kube_config'
+ANSIBLE_CONFIG: '${INFRASTRUCTURE_REPO}/inventory/${INVENTORY}/config/private/ansible.cfg'
+KUBECONFIG: '${INFRASTRUCTURE_REPO}/inventory/${INVENTORY}/config/private/kube_config'
 HELM_HOME: "${INFRASTRUCTURE_REPO}/helm"
 
 {%- if cloud | lower == 'aws' %}

--- a/pentagon/meta.py
+++ b/pentagon/meta.py
@@ -1,3 +1,3 @@
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 __author__ = 'ReactiveOps, Inc.'

--- a/pentagon/migration/migrations/migration_2_2_0.py
+++ b/pentagon/migration/migrations/migration_2_2_0.py
@@ -11,8 +11,6 @@ class Migration(migration.Migration):
 
     def run(self):
 
-        self.delete('{}/Makefile'.format(infrastructure_repo))
-
         for item in self.inventory:
             inventory_path = "inventory/{}".format(item)
             logging.debug('Inventory Path: {}'.format(inventory_path))

--- a/pentagon/migration/migrations/migration_2_3_1.py
+++ b/pentagon/migration/migrations/migration_2_3_1.py
@@ -1,0 +1,35 @@
+from pentagon import migration
+from pentagon.migration import *
+from pentagon.component import core, inventory
+from pentagon.helpers import merge_dict
+
+
+class Migration(migration.Migration):
+    _starting_version = '2.3.1'
+    _ending_version = '2.4.0'
+
+    def run(self):
+        for item in self.inventory:
+            inventory_path = "inventory/{}".format(item)
+            logging.debug(
+                'Processing Inventory Item: {}'
+                .format(inventory_path)
+            )
+            with self.YamlEditor('{}/config/local/vars.yml'.format(inventory_path)) as vars_yml:
+                vars_yml_dict = vars_yml.get_data()
+
+            logging.info('Found KUBECONFIG in vars.yml = {}'
+                         .format(vars_yml_dict.get('KUBECONFIG')))
+            logging.info('Found ANSIBLE_CONFIGin vars.yml = {}'
+                         .format(vars_yml_dict.get('ANSIBLE_CONFIG')))
+            vars_yml_dict['KUBECONFIG'] = '${INFRASTRUCTURE_REPO}/inventory/${INVENTORY}/config/private/kube_config'
+            vars_yml_dict['ANSIBLE_CONFIG'] = '${INFRASTRUCTURE_REPO}/inventory/${INVENTORY}/config/private/ansible.cfg'
+            logging.info('Changed KUBECONFIG to be {}'
+                         .format(vars_yml_dict.get('KUBECONFIG')))
+            logging.info('Changed ANSIBLE_CONFIG to be {}'
+                         .format(vars_yml_dict.get('ANSIBLE_CONFIG')))
+
+            logging.warn(
+                '####### IMPORTANT: Your kube and ansible config paths have changed.')
+
+            vars_yml.write()


### PR DESCRIPTION
I noticed that the original vars.yaml was created with the `default` name but someone later copy
pasted the vars.yaml file into other inventory folders. This resulted in kubeconfig context always creating
an `./inventory/default/` folder when there were only `/inventory/production/` and `/inventory/working/`
folders. This would also bleed changes between different `pentagon_workon` environments when you use
`kubectx` or `kubens` to change context information (because both envs would point at one KUBECONFIG).

This change also fixes an issue I had hit a few times where I would `pentagon_workon <client>` and it would make a new file in the repo and thus I would have a dirty git status on a file that should never be committed to the repository.