### PR TITLE
Remove deprecated TF VPC module variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.6.1 - 2018-10-30
+
+## Fixed
+- Remove deprecated VPC Terraform module variables.
+
 ## 2.6.0 - 2018-10-29
 
 ### Updated

--- a/pentagon/meta.py
+++ b/pentagon/meta.py
@@ -1,3 +1,3 @@
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"
 __author__ = 'ReactiveOps, Inc.'

--- a/pentagon/migration/migrations/migration_2_6_0.py
+++ b/pentagon/migration/migrations/migration_2_6_0.py
@@ -1,0 +1,28 @@
+from pentagon import migration
+from pentagon.migration import *
+from pentagon.component import core, inventory
+from pentagon.helpers import merge_dict
+
+import re
+
+
+class Migration(migration.Migration):
+    _starting_version = '2.6.0'
+    _ending_version = '2.6.1'
+
+    def run(self):
+        for item in self.inventory:
+            inventory_path = "inventory/{}".format(item)
+            logging.debug(
+                'Processing Inventory Item: {}'
+                .format(inventory_path)
+            )
+
+            # Remove deprecated variables from VPC TF module usage
+            aws_vpc_vars_file = "{}/terraform/aws_vpc_variables.tf".format(inventory_path)
+            if os.path.exists(aws_vpc_vars_file):
+                aws_vpc_vars_file_content = self.get_file_content(aws_vpc_vars_file)
+                aws_vpc_vars_file_content = re.sub(r'\n\s*variable "aws_access_key" {}', '', aws_vpc_vars_file_content)
+                aws_vpc_vars_file_content = re.sub(r'\n\s*variable "aws_secret_key" {}', '', aws_vpc_vars_file_content)
+                self.overwrite_file(aws_vpc_vars_file, aws_vpc_vars_file_content)
+                logging.info('Deprecated Terraform VPC module variables removed in {}'.format(item))


### PR DESCRIPTION
Missed removing these in the 2.6.0 migration that updated the VPC
module. Add a new migration to remove them.