### PR TITLE
Add kops cluster YAML to initialize AWS IAM Authenticator

### DIFF
--- a/pentagon/component/kops/files/cluster.yml.jinja
+++ b/pentagon/component/kops/files/cluster.yml.jinja
@@ -36,6 +36,7 @@ spec:
       encryptedVolume: true
     {%- endfor %}
   kubeAPIServer:
+    authenticationTokenWebhookConfigFile: /srv/kubernetes/aws-iam-authenticator/kubeconfig.yaml
     auditLogPath: /var/log/kube-apiserver-audit.log
     auditLogMaxAge: 10
     auditLogMaxBackups: 1
@@ -230,3 +231,19 @@ spec:
         - level: Metadata
           omitStages:
             - "RequestReceived"
+  hooks:
+   - name: kops-hook-authenticator-config.service
+     before:
+       - kubelet.service
+     roles: [Master]
+     manifest: |
+       [Unit]
+         Description=Initialize AWS IAM Authenticator cert and Kube API Server config
+       [Service]
+         Type=oneshot
+        ExecStartPre=/bin/mkdir -p /srv/kubernetes/aws-iam-authenticator
+        ExecStartPre=/bin/sh -c '/usr/bin/test -r /srv/kubernetes/aws-iam-authenticator/README || /bin/echo These files were created by the kops-hook-authenticator-config service, which ran aws-iam-authenticator init via a temporary Docker container. >/srv/kubernetes/aws-iam-authenticator/README'
+        ExecStartPre=/bin/chown 10000:10000 /srv/kubernetes/aws-iam-authenticator
+        ExecStartPost=/bin/sh -c '(/usr/bin/id -u aws-iam-authenticator >/dev/null 2>&1 || /usr/sbin/groupadd -g 10000 aws-iam-authenticator) ; (/usr/bin/id -u aws-iam-authenticator >/dev/null 2>&1 || /usr/sbin/useradd -s /usr/sbin/nologin -c "AWS IAM Authenticator configs" -d /srv/kubernetes/aws-iam-authenticator -u 10000 -g aws-iam-authenticator aws-iam-authenticator)'
+        ExecStart=/bin/sh -c '(set -x ; /usr/bin/docker run --net=host --rm -w /srv/kubernetes/aws-iam-authenticator -v /srv/kubernetes/aws-iam-authenticator:/srv/kubernetes/aws-iam-authenticator --name aws-iam-authenticator-initialize gcr.io/heptio-images/authenticator:v0.3.0 init -i clustername ; /bin/mv /srv/kubernetes/aws-iam-authenticator/heptio-authenticator-aws.kubeconfig /srv/kubernetes/aws-iam-authenticator/kubeconfig.yaml)'
+


### PR DESCRIPTION
The kops component will create a cluster ready for the AWS IAM
Authenticator daemonset to be deployed. Pod volumes should be mounted to
`/srv/kubernetes/aws-iam-authenticator`, as is typical in most kops
implementations of AWS IAM Authenticator.

Using the AWS IAM Authenticator container image to create the
certificate and Kubernetes API Server config avoids a cluster update,
and allows managing the AWS IAM Authenticator daemonset outside of kops.