### PR TITLE
Add support for custom jinja filters

### DIFF
--- a/pentagon/filters.py
+++ b/pentagon/filters.py
@@ -2,7 +2,7 @@ import re
 
 
 
-def get_filters():
+def register_filters():
 	"""Register a function with decorator"""
 	registry = {}
 	def registrar(func):
@@ -12,7 +12,13 @@ def get_filters():
 	return registrar
 
 
-filter = get_filters()
+filter = register_filters()
+
+
+
+def get_jinja_filters():
+	"""Return all registered custom jinja filters"""
+	return filter.all
 
 
 @filter
@@ -24,11 +30,3 @@ def regex_trim(input, regex, replace=''):
 	replace (string - optional): a string to replace any matches with.  Defaults to trimming the match.
 	"""
 	return re.sub(regex, replace, input)
-
-
-
-
-
-if __name__ == '__main__':
-	for k,v in filter.all.items():
-		print(v)

--- a/pentagon/filters.py
+++ b/pentagon/filters.py
@@ -1,7 +1,6 @@
 import re
 
 
-
 def register_filters():
 	"""Register a function with decorator"""
 	registry = {}
@@ -13,7 +12,6 @@ def register_filters():
 
 
 filter = register_filters()
-
 
 
 def get_jinja_filters():

--- a/pentagon/filters.py
+++ b/pentagon/filters.py
@@ -1,0 +1,34 @@
+import re
+
+
+
+def get_filters():
+	"""Register a function with decorator"""
+	registry = {}
+	def registrar(func):
+		registry[func.__name__] = func
+		return func 
+	registrar.all = registry
+	return registrar
+
+
+filter = get_filters()
+
+
+@filter
+def regex_trim(input, regex, replace=''):
+	"""
+	Trims or replaces the regex match in an input string.
+	input (string): the input string to search for matches
+	regex (string): regex to match
+	replace (string - optional): a string to replace any matches with.  Defaults to trimming the match.
+	"""
+	return re.sub(regex, replace, input)
+
+
+
+
+
+if __name__ == '__main__':
+	for k,v in filter.all.items():
+		print(v)

--- a/pentagon/helpers.py
+++ b/pentagon/helpers.py
@@ -8,6 +8,7 @@ import oyaml as yaml
 from Crypto.PublicKey import RSA
 from stat import *
 from collections import OrderedDict
+import filters as jinja_filters
 
 
 def render_template(template_name, template_path, target, context, delete_template=True, overwrite=False):
@@ -35,6 +36,9 @@ def render_template(template_name, template_path, target, context, delete_templa
     with open(target, 'w+') as vars_file:
         try:
             template = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path)).get_template(template_name)
+            for k,v in jinja_filters.get_jinja_filters().items():
+                template.filters[k] = v
+
             vars_file.write(template.render(context))
         except Exception, e:
             logging.error("Error writing {}. {}".format(target, traceback.print_exc(e)))

--- a/pentagon/helpers.py
+++ b/pentagon/helpers.py
@@ -35,10 +35,11 @@ def render_template(template_name, template_path, target, context, delete_templa
 
     with open(target, 'w+') as vars_file:
         try:
-            template = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path)).get_template(template_name)
+            env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
             for k,v in jinja_filters.get_jinja_filters().items():
-                template.filters[k] = v
+                env.filters[k] = v
 
+            template = env.get_template(template_name)
             vars_file.write(template.render(context))
         except Exception, e:
             logging.error("Error writing {}. {}".format(target, traceback.print_exc(e)))


### PR DESCRIPTION
Implements #171 

This PR adds support for custom jinja filters, and I added one custom filter, `regex_trim`.  Custom filters are required for more complex templates like what would be required to implement reactiveops/rodd#1 and reactiveops/rodd#37.  Any methods defined in filters.py with the `@filter` decorator will be loaded into the template environment for use.

