### PR TITLE
Fix node_count default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.1.2
+### Fixed
+- Changed `defaults.node_count` from 3 to 1, so that only 3 total nodes (one per `InstanceGroup`) are created
+
 ## 3.1.1
-## Fixed
+### Fixed
 - In certain cases a migration would cause duplicate hooks
 - In certain cases, migrations were not run because kops.sh had been deleted
 

--- a/pentagon/defaults.py
+++ b/pentagon/defaults.py
@@ -19,7 +19,7 @@ class AWSPentagonDefaults(object):
         'network_mask': 24,
         'networking': {'flannel': {'backend': 'vxlan'}},
         'node_additional_policies': '[{"Effect": "Allow","Action": ["autoscaling:DescribeAutoScalingGroups", "autoscaling:DescribeAutoScalingInstances", "autoscaling:DescribeTags", "autoscaling:SetDesiredCapacity", "autoscaling:TerminateInstanceInAutoScalingGroup"],"Resource": "*"}]',
-        'node_count': 3,
+        'node_count': 1,
         'node_root_volume_size': 200,
         'production_third_octet': 16,
         'ssh_key_path': '~/.ssh/id_rsa.pub',

--- a/pentagon/meta.py
+++ b/pentagon/meta.py
@@ -1,2 +1,2 @@
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 __author__ = 'ReactiveOps, Inc.'


### PR DESCRIPTION
Was working with EJ and noticed that after running `pentagon start-project` and `runner cluster_configure`, the file `inventory/default/clusters/$cluster/cluster-config/nodes.yml` had three `InstanceGroup`s with `maxSize=minSize=3`, resulting in a total of 9 nodes (3 per subnet), rather than the desired 3 nodes (1 per subnet). From what I understand, we recently switched from having one IG spread across 3 subnets, to one IG per subnet - guessing this is an artifact of that change.

Changing this default sets `ig_max_size=ig_min_size=1` in `inventory/default/clusters/$cluster/vars.yml`, which results in `maxSize=minSize=1` in `nodes.yml`.

Let me know if there's a better way to fix this.